### PR TITLE
empty node for radio since wb6.5 instead of deleting the node

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard65.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard65.dts
@@ -4,14 +4,15 @@
 
 /* cleanup deprecated radio bindings */
 /delete-node/ &spi_rfm69;
-/delete-node/ &pinctrl_rfm69_spi_irq;
+/delete-node/ &pinctrl_rfm69_spi_irq; /* pins from radio are using in wb6.7.x */
 
 / {
 	model = "Wiren Board rev. 6.5 (i.MX6UL/ULL)";
 	compatible = "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
 
-	aliases { /* radio has moved to wb-hwconf-manager & another spi bus */
-		/delete-property/ spi10;
+	spi_rfm69: spi-rfm69 {
+		/* Wb-dt-overlays's wb6-noradio overlay is looking into spi_rfm69 node.
+		Empty node here is to prevent overlay-applying conflicts. */
 	};
 
 	wirenboard {
@@ -20,8 +21,8 @@
 		/delete-node/ radio;
 
 		radio {
-			status = "disabled";
-			model = "none";
+			/* Wb-dt-overlays's wb6-noradio overlay is looking into radio node.
+			Empty node here is to prevent overlay-applying conflicts. */
 		};
 
 		gpios {
@@ -50,5 +51,3 @@
 		};
     };
 };
-
-


### PR DESCRIPTION
wb-dt-overlays оверлеем wb6-noradio пишет в ноды spi_rfm69 и radio. Нода spi_rfm69 была удалена, и при загрузке оверлея noradio WB проваливался в wirenboard-boot-failsafe из-за записи параметров в несуществующую ноду. 
Решили для таких случаев в ядре делать пустые ноды, которые будут наполняться уже из wb-dt-overlays.

По мотивам [этого](https://github.com/wirenboard/linux/pull/36) PR