### PR TITLE
removed duplicating (with wb-hwconf-manager) uart7 rts property

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard670.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard670.dts
@@ -216,11 +216,6 @@
 	>;
 };
 
-// uart on mod3
-&uart7 {
-	rts-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
-};
-
 &uart8 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart8>;


### PR DESCRIPTION
rts (у uart7) зачем-то был указан драйверу напрямую (хотя это делает hwconf) => когда понадобился pps модуля gps, нужный gpio был занят