### PR TITLE
gpio: mcp23s08: use edge-triggered interrupts

### DIFF
--- a/drivers/gpio/gpio-mcp23s08.c
+++ b/drivers/gpio/gpio-mcp23s08.c
@@ -460,9 +460,9 @@ static int mcp23s08_irq_setup(struct mcp23s08 *mcp)
 	mutex_init(&mcp->irq_lock);
 
 	if (mcp->irq_active_high)
-		irqflags |= IRQF_TRIGGER_HIGH;
+		irqflags |= IRQF_TRIGGER_RISING;
 	else
-		irqflags |= IRQF_TRIGGER_LOW;
+		irqflags |= IRQF_TRIGGER_FALLING;
 
 	err = devm_request_threaded_irq(chip->parent, mcp->irq, NULL,
 					mcp23s08_irq,


### PR DESCRIPTION
This prevents deadlock on startup when INT line is held low during
startup of mcp23s08 module. Interrupt is cleared by talking to all
mcp23s08 devices sharing same INT line. On startup, the devieces
are probed one by one. The first device probed initialize IRQ handler
on INT line. Since the other deviecs sharing INT line are not probed
at this point, interrupt cannot be cleared.
Continuos interrupt handling, in turn, will prevent other devices to
be probed by blocking i2c bus.

Edge triggered interrupts are triggered only once, thus preventing the
aforementioned scenario.

s in this case interrupt can't be cleared