### PR TITLE
Bugfix/5.10 unstable eth0

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -491,6 +491,8 @@
 		ethphy0: ethernet-phy@0 {
 			reg = <0>;
 			smsc,disable-energy-detect;
+			clocks = <&clks IMX6UL_CLK_ENET_REF>;
+			clock-names = "rmii-ref";
 		};
 
 		ethphy3: ethernet-phy@3 {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb2) stable; urgency=medium
+
+  * fix unstable link on eth0 on some units
+
+ -- Evgeny Boger <boger@contactless.ru>  Tue, 01 Jun 2021 20:20:05 +0300
+
 linux-wb (5.10.35-wb1) stable; urgency=medium
 
   * merge linux-stable/v.5.10.y, 5.10.35

--- a/drivers/net/phy/smsc.c
+++ b/drivers/net/phy/smsc.c
@@ -152,9 +152,12 @@ static int lan87xx_config_aneg(struct phy_device *phydev)
 	return genphy_config_aneg(phydev);
 }
 
-static int lan87xx_config_aneg_ext(struct phy_device *phydev)
+static int lan95xx_config_aneg_ext(struct phy_device *phydev)
 {
 	int rc;
+
+	if (phydev->phy_id != 0x0007c0f0) /* not (LAN9500A or LAN9505A) */
+		return lan87xx_config_aneg(phydev);
 
 	/* Extend Manual AutoMDIX timer */
 	rc = phy_read(phydev, PHY_EDPD_CONFIG);
@@ -408,7 +411,7 @@ static struct phy_driver smsc_phy_driver[] = {
 	.read_status	= lan87xx_read_status,
 	.config_init	= smsc_phy_config_init,
 	.soft_reset	= smsc_phy_reset,
-	.config_aneg	= lan87xx_config_aneg_ext,
+	.config_aneg	= lan95xx_config_aneg_ext,
 
 	/* IRQ related */
 	.ack_interrupt	= smsc_phy_ack_interrupt,


### PR DESCRIPTION
Чинит нестабильный линк на первом ethernet. Проблема проявляется не на всех контроллерах, но на двух воспроизводилась стабильно.

Исправление - в dts, заодно на всякий случай притащил коммит из 5.11 на тот же phy, который потенцинально чинит проблемы.