### PR TITLE
new dts for wb6.8.x (rtc_clkout is gpio)

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -435,7 +435,8 @@ dtb-$(CONFIG_SOC_IMX6UL) += \
 	imx6ul-wirenboard61.dtb \
 	imx6ul-wirenboard65.dtb \
 	imx6ul-wirenboard660.dtb \
-	imx6ul-wirenboard670.dtb
+	imx6ul-wirenboard670.dtb \
+	imx6ul-wirenboard680.dtb
 dtb-$(CONFIG_SOC_IMX7D) += \
 	imx7d-cl-som-imx7.dtb \
 	imx7d-colibri-eval-v3.dtb \

--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -194,7 +194,7 @@
 
 		status = "okay";
 
-		rtc@51 {
+		rtc_pcf: rtc@51 {
 			compatible = "nxp,pcf8563";
 			reg = <0x51>;
 		};

--- a/arch/arm/boot/dts/imx6ul-wirenboard680.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard680.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+
+#include "imx6ul-wirenboard670.dts"
+
+/ {
+	model = "Wiren Board rev. 6.8.0 (i.MX6UL/ULL)";
+	compatible = "contactless,imx6ul-wirenboard680", "contactless,imx6ul-wirenboard670", "contactless,imx6ul-wirenboard660", "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
+};
+
+&iomuxc {
+	pinctrl_rtc_clkout: rtc-clkoutgrp {
+		fsl,pins = <
+			MX6UL_PAD_GPIO1_IO00__GPIO1_IO00 0x70b0 /*47K PU*/
+		>;
+	};
+};
+
+&rtc_pcf {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rtc_clkout>;
+	clkout-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (4.9.22-wb2) stable; urgency=medium
+
+  * Defined RTC_CLKOUT as gpio in WB6.8+
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 24 Jun 2021 15:37:11 +0300
+
 linux-wb (4.9.22-wb1) stable; urgency=medium
 
   * Initial release


### PR DESCRIPTION
Новая dts для WB6.8
Вывели RTC_CLKOUT на gpio

![123](https://user-images.githubusercontent.com/25829054/123279831-e9954900-d510-11eb-977e-a4ee19ab6427.jpg)


test-suite прошел