### PR TITLE
new dts for wb6.8.x (rtc_clkout is gpio)

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -631,6 +631,7 @@ dtb-$(CONFIG_SOC_IMX6UL) += \
 	imx6ul-wirenboard65.dtb \
 	imx6ul-wirenboard660.dtb \
 	imx6ul-wirenboard670.dtb \
+	imx6ul-wirenboard680.dtb \
 	imx6ull-14x14-evk.dtb \
 	imx6ull-colibri-eval-v3.dtb \
 	imx6ull-colibri-wifi-eval-v3.dtb \

--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -211,7 +211,7 @@
 
 		status = "okay";
 
-		rtc@51 {
+		rtc_pcf: rtc@51 {
 			compatible = "nxp,pcf8563";
 			reg = <0x51>;
 		};

--- a/arch/arm/boot/dts/imx6ul-wirenboard680.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard680.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+
+#include "imx6ul-wirenboard670.dts"
+
+/ {
+	model = "Wiren Board rev. 6.8.0 (i.MX6UL/ULL)";
+	compatible = "contactless,imx6ul-wirenboard680", "contactless,imx6ul-wirenboard670", "contactless,imx6ul-wirenboard660", "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
+};
+
+&iomuxc {
+	pinctrl_rtc_clkout: rtc-clkoutgrp {
+		fsl,pins = <
+			MX6UL_PAD_GPIO1_IO00__GPIO1_IO00 0x70b0 /*47K PU*/
+		>;
+	};
+};
+
+&rtc_pcf {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rtc_clkout>;
+	clkout-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb3) stable; urgency=medium
+
+  * Defined RTC_CLKOUT as gpio in WB6.8+
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 25 Jun 2021 19:41:11 +0300
+
 linux-wb (5.10.35-wb2) stable; urgency=medium
 
   * fix unstable link on eth0 on some units


### PR DESCRIPTION
Перенес dts для wb6.8 из стабильного ядра