### PR TITLE
dts: disable rts-gpios on WB6 modX uarts by default

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -548,7 +548,6 @@
 
 // uart on mod1
 &uart3 {
-	rts-gpios = <&gpio1 26 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
@@ -561,7 +560,6 @@
 
 // uart on mod2
 &uart5 {
-	rts-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
@@ -574,7 +572,6 @@
 
 // uart on mod3
 &uart7 {
-	rts-gpios = <&gpio3 11 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 

--- a/arch/arm/boot/dts/imx6ul-wirenboard670.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard670.dts
@@ -150,13 +150,11 @@
 
 // uart on mod3; look into hwconf-manager for actual namings
 &uart6 {
-	rts-gpios = <&gpio4 19 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
 // uart on mod4; look into hwconf-manager for actual namings
 &uart7 {
-	rts-gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-wb (5.10.35-wb6) stable; urgency=medium
+
+  * dts: remove rts-gpios from WB6 dts by default.
+    This fixes some internal Wiren Board modules such as GPS and Zigbee
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 29 Sep 2021 22:40:39 +0300
+
 linux-wb (5.10.35-wb5) stable; urgency=medium
 
   * LIRC and SC16IS7XX drivers are included into imx6_wirenboard_defconfig 

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -333,7 +333,7 @@ Package: $packagename
 Provides: linux-image, linux-image-2.6, linux-modules-$version
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
 Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
-Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.38.3)
+Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~)
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description


### PR DESCRIPTION
These rts-gpios are now set expicitly in wb-hwconf-manager overlays where it is necessary (https://github.com/wirenboard/wb-hwconf-manager/pull/47)