### PR TITLE
builddeb: conflict on linux-image to forbid multiple images

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb104) stable; urgency=medium
+
+  * make linux-image-wb6 and linux-image-wb7 conflict
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 01 Feb 2022 00:58:49 +0300
+
 linux-wb (5.10.35-wb103) stable; urgency=medium
 
   * dts: fixed unstable eth connection on wb6.9

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -333,7 +333,7 @@ Package: $packagename
 Provides: linux-image, linux-image-2.6, linux-modules-$version
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
 Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
-Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~)
+Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description


### PR DESCRIPTION
Добавил в пакет `Conflicts: linux-image`, чтобы пакеты с ядрами конфликтовали друг с другом и не пытались устанавливаться одновременно (сейчас из-за этого поломан unstable)