### PR TITLE
wb7: defined proper modem's gpios and usb-soc addr

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -453,6 +453,22 @@
 	};
 };
 
+/* wbc-modem is connected to port3 of usb-hub */
+&usbotg2 {
+	usb-hub@1 {
+		compatible = "usb424,2514";
+		reg = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wbc-modem@3 {
+			compatible = "wirenboard,wbc-usb-modem";
+			reg = <3>;
+		};
+	};
+};
+
+
 &clks {
 	assigned-clocks = <&clks IMX6UL_CLK_PLL4_AUDIO_DIV>;
 	assigned-clock-rates = <786432000>;

--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -455,7 +455,7 @@
 	};
 };
 
-/* wbc-modem is connected to port3 of usb-hub */
+/* wbc-modem is connected to port2 of usb-hub */
 &usbotg2 {
 	usb-hub@1 {
 		compatible = "usb424,2514";
@@ -463,9 +463,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		wbc_modem: wbc-modem@3 {
+		wbc_modem: wbc-modem@2 {
 			compatible = "wirenboard,wbc-usb";
-			reg = <3>;
+			reg = <2>;
 			status = "disabled";
 
 			power-type = <2>;

--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -466,6 +466,7 @@
 		wbc_modem: wbc-modem@3 {
 			compatible = "wirenboard,wbc-usb";
 			reg = <3>;
+			status = "disabled";
 
 			power-type = <2>;
 			power-gpios = <&gpio4 24 0>;

--- a/arch/arm/boot/dts/imx6ul-wirenboard61.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard61.dts
@@ -20,6 +20,7 @@
 		spi10 = &spi_rfm69;
 		usb0 = &usbotg1;
 		usb1 = &usbotg2;
+		wbc_modem = &wbc_modem;
 /*
     Swap mmc0 and mmc1 aliases
 
@@ -421,7 +422,8 @@
 			};
 		};
 
-		gsm {
+		gsm {  // left for 2g-only modems compatibility
+			compatible = "wirenboard,wbc-uart";
 			power-type = <2>;
 			power-gpios = <&gpio4 24 0>;
 			pwrkey-gpios = <&gpio3 20 0>;
@@ -461,9 +463,15 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		wbc-modem@3 {
-			compatible = "wirenboard,wbc-usb-modem";
+		wbc_modem: wbc-modem@3 {
+			compatible = "wirenboard,wbc-usb";
 			reg = <3>;
+
+			power-type = <2>;
+			power-gpios = <&gpio4 24 0>;
+			pwrkey-gpios = <&gpio3 20 0>;
+			status-gpios = <&gpio3 19 1>;
+			simselect-gpios = <&gpio3 24 0>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/imx6ul-wirenboard670.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard670.dts
@@ -34,6 +34,10 @@
     };
 };
 
+&wbc_modem {
+	power-gpios = <&gpio5 4 0>;
+};
+
 &ecspi3 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_ecspi3>;

--- a/arch/arm/boot/dts/imx6ul-wirenboard670.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard670.dts
@@ -34,7 +34,9 @@
     };
 };
 
+/* wbc-modem is connected to port3 of usb-hub */
 &wbc_modem {
+	reg = <3>;
 	power-gpios = <&gpio5 4 0>;
 };
 

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
@@ -54,7 +54,7 @@
 			enable-active-high;
 		};
 
-		/* USB Wi-Fi is directly connected to SoC, power supply is 
+		/* USB Wi-Fi is directly connected to SoC, power supply is
 		   switched by dedicated P-channel FET */
 		reg_usb_wifi_3v3: regulator@2 {
 			reg = <2>;
@@ -316,6 +316,20 @@
 			};
 		};
 
+		gsm {
+			usb-soc-addr = "1c1c000";	// ehci2; modem is connected to
+
+			power-type = <2>;
+
+			/* keeps compatibility in wb of-parsing tools */
+			gpio-xlate-type = "bank_pin";
+			gpio-pins-per-bank = <32>;
+
+			power-gpios = <PIN_PD 27 GPIO_ACTIVE_HIGH>;
+			pwrkey-gpios = <PIN_PD 26 GPIO_ACTIVE_HIGH>;
+			status-gpios = <PIN_PD 25 GPIO_ACTIVE_LOW>;
+			simselect-gpios = <PIN_PB 2 GPIO_ACTIVE_HIGH>;
+		};
 
 		hwmon-nodes {
 			cputemp {
@@ -418,7 +432,7 @@
 	vcc-pa-supply = <&reg_dcdc1>; //ok
 	// vcc-pb-supply = <&reg_dcdc1>; /* VCC-IO */
 	vcc-pc-supply = <&reg_aldo2>; /* eMMC, SoM wi-fi gpios*/
-	vcc-pd-supply = <&reg_dcdc1>; //ok 
+	vcc-pd-supply = <&reg_dcdc1>; //ok
 	vcc-pe-supply = <&reg_eldo3>; //ok
 	vcc-pf-supply = <&reg_dcdc1>; //ok
 	vcc-pg-supply = <&reg_dcdc1>; // microSD 3v3!!

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
@@ -317,8 +317,6 @@
 		};
 
 		gsm {
-			usb-soc-addr = "1c1c000";	// ehci2; modem is connected to
-
 			power-type = <2>;
 
 			/* keeps compatibility in wb of-parsing tools */
@@ -713,6 +711,12 @@
 
 &ehci2 {
 	status = "okay";
+
+	/* wbc-modem is connected to 1st port of usb bus */
+	wbc-modem@1 {
+		compatible = "wirenboard,wbc-usb-modem";
+		reg = <1>;
+	};
 };
 
 

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
@@ -706,6 +706,7 @@
 
 		compatible = "wirenboard,wbc-usb";
 		power-type = <2>;
+		status = "disabled";
 
 		/* keeps compatibility in wb of-parsing tools */
 		gpio-xlate-type = "bank_pin";

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
@@ -32,6 +32,7 @@
 		mmc1 = &mmc0;
 		rtc0 = &ext_rtc;
 		rtc1 = &rtc;
+		wbc_modem = &wbc_modem;
 	};
 
 	chosen {
@@ -314,19 +315,6 @@
 				output-high;
 				sort-order = <9>;
 			};
-		};
-
-		gsm {
-			power-type = <2>;
-
-			/* keeps compatibility in wb of-parsing tools */
-			gpio-xlate-type = "bank_pin";
-			gpio-pins-per-bank = <32>;
-
-			power-gpios = <PIN_PD 27 GPIO_ACTIVE_HIGH>;
-			pwrkey-gpios = <PIN_PD 26 GPIO_ACTIVE_HIGH>;
-			status-gpios = <PIN_PD 25 GPIO_ACTIVE_LOW>;
-			simselect-gpios = <PIN_PB 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		hwmon-nodes {
@@ -713,9 +701,19 @@
 	status = "okay";
 
 	/* wbc-modem is connected to 1st port of usb bus */
-	wbc-modem@1 {
-		compatible = "wirenboard,wbc-usb-modem";
+	wbc_modem: wbc-modem@1 {
 		reg = <1>;
+
+		compatible = "wirenboard,wbc-usb";
+		power-type = <2>;
+
+		/* keeps compatibility in wb of-parsing tools */
+		gpio-xlate-type = "bank_pin";
+		gpio-pins-per-bank = <32>;
+		power-gpios = <PIN_PD 27 GPIO_ACTIVE_HIGH>;
+		pwrkey-gpios = <PIN_PD 26 GPIO_ACTIVE_HIGH>;
+		status-gpios = <PIN_PD 25 GPIO_ACTIVE_LOW>;
+		simselect-gpios = <PIN_PB 2 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb105) stable; urgency=medium
+
+  * wb7: defined proper modem's gpios and usb-soc addr
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 02 Feb 2022 02:39:41 +0300
+
 linux-wb (5.10.35-wb104) stable; urgency=medium
 
   * make linux-image-wb6 and linux-image-wb7 conflict

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 linux-wb (5.10.35-wb106) stable; urgency=medium
 
-  * wb7: defined proper modem's gpios and usb-soc addr
+  * wb7: defined proper modem's gpios
+  * wb6, wb7: binded modem's usb port
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 04 Feb 2022 10:03:51 +0300
 


### PR DESCRIPTION
Поддержка модемов в wb7. Правильно разворачиваются gpio, появился адрес нужного usb

Связанные PR: [wb-utils](https://github.com/wirenboard/wb-utils/pull/37), [hwconf](https://github.com/wirenboard/wb-hwconf-manager/pull/70/)