### PR TITLE
wb6.9: fixed incorrect clk on fec2

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard690.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard690.dts
@@ -120,7 +120,7 @@
 		ethphy1: ethernet-phy@1 {
 			compatible = "ethernet-phy-ieee802.3-c22";
 			reg = <1>;
-			clocks = <&clks IMX6UL_CLK_ENET_REF>;
+			clocks = <&clks IMX6UL_CLK_ENET2_REF_125M>;  // looks like naming bug; ordinary ref_clk
 			clock-names = "rmii-ref";
 			smsc,disable-energy-detect;
 			status = "okay";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb105) stable; urgency=medium
+
+  * wb6.9: fixed incorrect clk on fec2
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 02 Feb 2022 23:05:27 +0300
+
 linux-wb (5.10.35-wb104) stable; urgency=medium
 
   * make linux-image-wb6 and linux-image-wb7 conflict


### PR DESCRIPTION
клок на eth1 был, да не тот