### PR TITLE
dts: add compatible strings for all supported WB6x to wb6x-init

### DIFF
--- a/arch/arm/boot/dts/imx6ul-wirenboard6x-init.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard6x-init.dts
@@ -5,7 +5,6 @@
 / {
 	model = "Wiren Board init (i.MX6UL/ULL)";
 	compatible = "contactless,imx6ul-wirenboard6x-init", "contactless,imx6ul-wirenboard690", "contactless,imx6ul-wirenboard680", "contactless,imx6ul-wirenboard670", "contactless,imx6ul-wirenboard660", "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
-};
 
 	/delete-node/ mcp6542; // Defining 2 watchdog nodes: for wb6.x and wb 6.9.x
 

--- a/arch/arm/boot/dts/imx6ul-wirenboard6x-init.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard6x-init.dts
@@ -4,7 +4,8 @@
 
 / {
 	model = "Wiren Board init (i.MX6UL/ULL)";
-	compatible = "contactless,imx6ul-wirenboard6x-init", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
+	compatible = "contactless,imx6ul-wirenboard6x-init", "contactless,imx6ul-wirenboard690", "contactless,imx6ul-wirenboard680", "contactless,imx6ul-wirenboard670", "contactless,imx6ul-wirenboard660", "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
+};
 
 	/delete-node/ mcp6542; // Defining 2 watchdog nodes: for wb6.x and wb 6.9.x
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (4.9.22-wb4) stable; urgency=medium
+
+  * Added compatible strings for all supported Wiren Board devices to WB6x-init dts
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 10 Feb 2022 09:47:44 +0300
+
 linux-wb (4.9.22-wb3) stable; urgency=medium
 
   * Added universal WB6x-init dts


### PR DESCRIPTION
При обновлении с USB ядро теперь загружается с этим device tree, но в нём не были указаны устройства wb6 как compatible, поэтому скрипт обновления считает устройство несовместимым и обновление не происходит.

Это должно всё починить (до выпуска нового target-а wb6 для сборки образов).