### PR TITLE
Bugfix/wb7 wbio interrupts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb106) stable; urgency=medium
+
+  * wb7: fix interrupts on WBIO modules
+
+ -- Evgeny Boger <boger@wirenboard.com>  Sun, 20 Feb 2022 18:58:34 +0300
+
 linux-wb (5.10.35-wb105) stable; urgency=medium
 
   * wb6.9: fixed incorrect clk on fec2

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
@@ -885,7 +885,8 @@ static int sunxi_pinctrl_gpio_get_direction(struct gpio_chip *gc,
 		default:
 			dev_dbg(gc->parent, "%s: get direction GPIO %d, unexpected mux %x. Maybe request the pin first?\n",
 				gc->label, offset + gc->base, mux);
-			return -EINVAL;
+			/* Other code don't really expect errors routinely happening here, so return direction in instead */
+			return GPIO_LINE_DIRECTION_IN;
 	}
 }
 


### PR DESCRIPTION
похоже, что мир ещё не готов к возврату ошибки в get_direction() драйвера GPIO. Весь get_direction для sunxi я дописывал сам.

При чём тут прерывания: если юзерспейс запрашивает прерывание на ноге, то ядро линукса первым делом проверяет, не как выход ли настроена эта нога. Видимо в этот момент get_direction() возвращает ошибку, которая то ли где-то дальше не обрабатывается, то ли обрабатывается неправильно. Драйвер mcp23s008, исползующий прерывание, просто вываливается на probe.

Кажется, тут бы помогли gpio-hog, чтобы при старте контроллера gpio инициализировать ногу WBIO INT как вход. Но, сюрприз, при использовании gpio-hog ядро просто падает, причём даже до инициализации консоли. Отлаживать это некогда.

В любом случае, судя по коду, ret у get_direction() не обрабатывается вообще примерно никогда, поэтому проще ошибки оттуда не возвращать вообще.