### PR TITLE
wb6.7: added dummy (a copy of wb6.7's) dts for wb67-nousbhub devices

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -631,6 +631,7 @@ dtb-$(CONFIG_SOC_IMX6UL) += \
 	imx6ul-wirenboard65.dtb \
 	imx6ul-wirenboard660.dtb \
 	imx6ul-wirenboard670.dtb \
+	imx6ul-wirenboard670-nousbhub.dtb \
 	imx6ul-wirenboard680.dtb \
 	imx6ul-wirenboard690.dtb \
 	imx6ull-14x14-evk.dtb \

--- a/arch/arm/boot/dts/imx6ul-wirenboard670-nousbhub.dts
+++ b/arch/arm/boot/dts/imx6ul-wirenboard670-nousbhub.dts
@@ -1,0 +1,8 @@
+/dts-v1/;
+
+#include "imx6ul-wirenboard670.dts"
+
+/ {
+	model = "Wiren Board rev. 6.7.0 (i.MX6UL/ULL)";
+	compatible = "contactless,imx6ul-wirenboard670-nousbhub", "contactless,imx6ul-wirenboard670", "contactless,imx6ul-wirenboard660", "contactless,imx6ul-wirenboard65", "contactless,imx6ul-wirenboard61", "contactless,imx6ul-wirenboard60", "contactless,imx6ul-wirenboard-evk", "fsl,imx6ul-14x14-evk", "fsl,imx6ul";
+};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb105+1) stable; urgency=medium
+
+  * wb6.7: added dummy (a copy of 6.7's) dts for wb6.7s without usb hub
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 13 Apr 2022 17:41:01 +0300
+
 linux-wb (5.10.35-wb105) stable; urgency=medium
 
   * wb6.9: fixed incorrect clk on fec2


### PR DESCRIPTION
пустая wb67-nousbhub dts (для того, чтобы прописать контроллерам в factory_fdt)

погонял у себя на столе (еще и с [тестиком](https://github.com/wirenboard/test-suite/pull/168)) - всё работает, как и задумывалось