### PR TITLE
serial: 8250: fix rs-485 rx glitches in half-duplex

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-wb (5.10.35-wb111) stable; urgency=medium
+
+  * Fixes the 00 byte (and a break condition) received while sending large
+    enough buffers by RS-485 on Wiren Board 7
+
+ -- Evgeny Boger <boger@wirenboard.com>  Mon, 18 Apr 2022 23:39:39 +0300
+
 linux-wb (5.10.35-wb110) stable; urgency=medium
 
   * wb6.7.x: added imx6ul-wirenboard670-nousbhub dts (wbc-modem is connected directly to SoC's usb)

--- a/include/linux/serial_8250.h
+++ b/include/linux/serial_8250.h
@@ -140,6 +140,7 @@ struct uart_8250_port {
 	/* Serial port overrun backoff */
 	struct delayed_work overrun_backoff;
 	u32 overrun_backoff_time_ms;
+	bool rx_disabled;
 };
 
 static inline struct uart_8250_port *up_to_u8250p(struct uart_port *up)


### PR DESCRIPTION
In half-duplex RS-485 driver must ignore RX line while transmit driver
is enabled. Otherwise, depending on the wiring, one can receive echo,
framing errors, break condition or even the random noise.

Unfortunately, 8250 uarts do not allow to switch off the receiver.
To work around this, the current implementation disables the RX
interrupts during the transmission and clears RX FIFOs once the
transmission is completed to discard received data.

However, the receive path (serial8250_rx_chars) can still be activated
from interrupt handler during the transmission. The interrupt that can
occur during the transmission is TX FIFO threshold interrupt, so the
erroneous behaviour is observed while sendinig chunks of data larger
than FIFO threshold.

This patch fixes that by setting a flag during the transmission and then
by checking the said flag in interrupt handler.