### PR TITLE
ADS1115 detection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+linux-wb (5.10.35-wb114) stable; urgency=medium
+
+  * ADS1115 detection
+    Some WBIO-AI-DV-12 can have ADS1115 instead of ADS1015. They have different conversion times.
+    Using ti-ads1015 driver for them will lead to reading wrong values.
+    To detect such devices the driver uses Lo_thresh register.
+    4 LSB in ADS1015's Lo_thresh register are read only, they are always zero.
+    ADS1115's Lo_thresh is completely writable.
+    The driver writes 0xFF and reads value back, if they are different, it is ADS1015.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 01 Jun 2022 10:46:18 +0500
+
 linux-wb (5.10.35-wb113) stable; urgency=medium
 
   * wb7: add missing drivers similar to wb6

--- a/drivers/iio/adc/ti-ads1015.c
+++ b/drivers/iio/adc/ti-ads1015.c
@@ -1086,7 +1086,7 @@ static int ads1015_probe(struct i2c_client *client,
 			data->real_data_rate = (unsigned int *) &ads1015_data_rate;
 		} else {
 			data->real_data_rate = (unsigned int *) &ads1115_data_rate;
-			dev_err(&client->dev, "The device is not ADS1015, seems to be ADS1115\n");
+			dev_warn(&client->dev, "The device is not ADS1015, seems to be ADS1115\n");
 		}
 	}
 


### PR DESCRIPTION
Some WBIO-AI-DV-12 can have ADS1115 instead of ADS1015. They have different conversion times.
Using ti-ads1015 driver for them will lead to reading wrong values.
To detect such devices driver uses Lo_thresh register.
4 LSB in ADS1015's Lo_thresh register are read only, they are always zero.
ADS1115's Lo_thresh is completely writable.
Driver writes 0xFF and reads value back.
If they are equal, it is ADS1115, and appropriate conversion times are used.


![изображение](https://user-images.githubusercontent.com/86825564/171346588-2dd03f1a-39c4-4746-9716-8044eeec4633.png)
