### PR TITLE
Feature/wb7 adc fixup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb115) stable; urgency=medium
+
+  * wb7: removed adc (a1-a3, vin) noise (fixups in sun4i-gpadc-iio driver)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 15 Jun 2022 01:05:48 +0300
+
 linux-wb (5.10.35-wb114) stable; urgency=medium
 
   * dts: wb7: add dts for WB 7.3 which supports ultra high-speed SD cards

--- a/drivers/iio/adc/sun4i-gpadc-iio.c
+++ b/drivers/iio/adc/sun4i-gpadc-iio.c
@@ -202,17 +202,13 @@ static int sun4i_prepare_for_irq(struct iio_dev *indio_dev, int channel,
 				   info->data->tp_mode_en |
 				   info->data->tp_adc_select |
 				   info->data->adc_chan_select(channel)) ||
+			/*
+			 * We need to clear adc's fifo just after setting the channel
+			 * (to clean previous channel's measurements)
+			 */
 			regmap_write(info->regmap, SUN4I_GPADC_INT_FIFOC,
 			   SUN4I_GPADC_INT_FIFOC_TP_FIFO_TRIG_LEVEL(1) |
 			   SUN4I_GPADC_INT_FIFOC_TP_FIFO_FLUSH);
-		/*
-		 * When the IP changes channel, it needs a bit of time to get
-		 * correct values.
-		 */
-		if ((reg & info->data->adc_chan_mask) !=
-			 info->data->adc_chan_select(channel))
-			usleep_range(10000, 20000);
-
 	} else {
 		/*
 		 * The temperature sensor returns valid data only when the ADC

--- a/drivers/iio/adc/sun4i-gpadc-iio.c
+++ b/drivers/iio/adc/sun4i-gpadc-iio.c
@@ -201,7 +201,10 @@ static int sun4i_prepare_for_irq(struct iio_dev *indio_dev, int channel,
 		ret = regmap_write(info->regmap, SUN4I_GPADC_CTRL1,
 				   info->data->tp_mode_en |
 				   info->data->tp_adc_select |
-				   info->data->adc_chan_select(channel));
+				   info->data->adc_chan_select(channel)) ||
+			regmap_write(info->regmap, SUN4I_GPADC_INT_FIFOC,
+			   SUN4I_GPADC_INT_FIFOC_TP_FIFO_TRIG_LEVEL(1) |
+			   SUN4I_GPADC_INT_FIFOC_TP_FIFO_FLUSH);
 		/*
 		 * When the IP changes channel, it needs a bit of time to get
 		 * correct values.


### PR DESCRIPTION
На всех wb7 присутствует проблема с adc. Для пользователя выглядит, как "периодические странные показания, когда к каналу не подключено ничего".
Экспериментально выяснено:
1) проблема точно программная (осцилл ничего не видит)
2) проблема на уровне ядра
3) основная гипотеза - adc успевает что-то намерить до того, как выбирается канал. Подтверждается экспериментально (см картинки; на них a1-a3, vin; поллятся раз в 0.5с). => видим измерения с другого канала

до фикса (a1-a3 пустые):
![2022-06-09_09-15-43](https://user-images.githubusercontent.com/25829054/173774070-b272f1d9-b2f5-46d5-9bd5-f7ccf4f8263f.png)

проверка гипотезы про fifo: отпаял vin; тем не менее видим на нем показания. Подключено: 0, 3v3, 5v, vin (разорвал)
![2022-06-15_11-15-03](https://user-images.githubusercontent.com/25829054/173777699-27d09d28-2ca0-4fca-bcae-d013d4804d1e.png)


