### PR TITLE
dts: wb7: add generic labels for ethernet adapters

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -992,6 +992,6 @@ even if no battery module is installed.
 	x-powers,charge-high-temp-microvolt = <499200>;
 };
 
-// labels used by overlays to control generic WB peripherals
-wb_eth0: &emac {};
-wb_eth1: &gmac {};
+// labels used by overlays to control generic peripherals
+ethernet0: &emac {};
+ethernet1: &gmac {};

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -991,3 +991,7 @@ even if no battery module is installed.
 	// to be overrided by battery overlay
 	x-powers,charge-high-temp-microvolt = <499200>;
 };
+
+// labels used by overlays to control generic WB peripherals
+wb_eth0: &emac {};
+wb_eth1: &gmac {};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb122) stable; urgency=medium
+
+  * dts: wb7: add generic labels for ethernet adapters
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 15 Nov 2022 21:13:50 +0600
+
 linux-wb (5.10.35-wb121) stable; urgency=medium
 
   * wb6, wb7: add bunch of kernel options for Docker


### PR DESCRIPTION
Нужно для того, чтобы заработал https://github.com/wirenboard/wb-dt-overlays/pull/6