### PR TITLE
dts: wb7: add generic labels for ethernet adapters (#107) (#108)

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -991,3 +991,7 @@ even if no battery module is installed.
 	// to be overrided by battery overlay
 	x-powers,charge-high-temp-microvolt = <499200>;
 };
+
+// labels used by overlays to control generic peripherals
+ethernet0: &emac {};
+ethernet1: &gmac {};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb120+wb1) stable; urgency=medium
+
+  * dts: wb7: add generic labels for ethernet adapters
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 15 Nov 2022 21:13:50 +0600
+
 linux-wb (5.10.35-wb120) stable; urgency=medium
 
   * wb7: add support for hw rev. 7.3.3


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/linux/pull/110