### PR TITLE
Revert 1-wire timings to kernel defaults

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-wb (5.10.35-wb120+wb101) stable; urgency=medium
+
+  * wb: more robust 1-wire readings. Fix regression in wb 5.10 kernel.
+    Revert 1-wire timings to kernel defaults
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 22 Nov 2022 10:40:41 +0500
+
 linux-wb (5.10.35-wb120+wb1) stable; urgency=medium
 
   * dts: wb7: add generic labels for ethernet adapters

--- a/drivers/w1/w1_io.c
+++ b/drivers/w1/w1_io.c
@@ -164,9 +164,9 @@ static u8 w1_read_bit(struct w1_master *dev)
 	/* sample timing is critical here */
 	local_irq_save(flags);
 	dev->bus_master->write_bit(dev->bus_master->data, 0);
-	w1_delay(5);
+	w1_delay(6);
 	dev->bus_master->write_bit(dev->bus_master->data, 1);
-	w1_delay(5);
+	w1_delay(9);
 
 	result = dev->bus_master->read_bit(dev->bus_master->data);
 	local_irq_restore(flags);


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/linux/pull/110