### PR TITLE
usb: msub: sunxi: set max speed from DT

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb129) stable; urgency=medium
+
+  * usb: msub: sunxi: set max speed from DT
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 17 Jan 2023 21:08:26 +0600
+
 linux-wb (5.10.35-wb128) stable; urgency=medium
 
   * rtl8723bu: fix disallow scan on buddy interface if configured as AP

--- a/drivers/usb/musb/sunxi.c
+++ b/drivers/usb/musb/sunxi.c
@@ -669,6 +669,7 @@ static struct musb_hdrc_config sunxi_musb_hdrc_config_h3 = {
 static int sunxi_musb_probe(struct platform_device *pdev)
 {
 	struct musb_hdrc_platform_data	pdata;
+	struct musb_hdrc_config	*config;
 	struct platform_device_info	pinfo;
 	struct sunxi_glue		*glue;
 	struct device_node		*np = pdev->dev.of_node;
@@ -721,11 +722,20 @@ static int sunxi_musb_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 	pdata.platform_ops	= &sunxi_musb_ops;
+
+	config = devm_kzalloc(&pdev->dev, sizeof(*config), GFP_KERNEL);
+	if (!config) {
+		return -ENOMEM;
+	}
+	pdata.config = config;
+
 	if (!of_device_is_compatible(np, "allwinner,sun8i-h3-musb") && 
 	    !of_device_is_compatible(np, "allwinner,sun8i-r40-musb"))
-		pdata.config = &sunxi_musb_hdrc_config;
+		*config = sunxi_musb_hdrc_config;
 	else
-		pdata.config = &sunxi_musb_hdrc_config_h3;
+		*config = sunxi_musb_hdrc_config_h3;
+
+	config->maximum_speed = usb_get_maximum_speed(&pdev->dev);
 
 	glue->dev = &pdev->dev;
 	INIT_WORK(&glue->work, sunxi_musb_work);

--- a/drivers/usb/musb/sunxi.c
+++ b/drivers/usb/musb/sunxi.c
@@ -669,7 +669,7 @@ static struct musb_hdrc_config sunxi_musb_hdrc_config_h3 = {
 static int sunxi_musb_probe(struct platform_device *pdev)
 {
 	struct musb_hdrc_platform_data	pdata;
-	struct musb_hdrc_config	*config;
+	struct musb_hdrc_config		*config;
 	struct platform_device_info	pinfo;
 	struct sunxi_glue		*glue;
 	struct device_node		*np = pdev->dev.of_node;


### PR DESCRIPTION
musb core driver will setup the hardware to full-speed or high-speed mode depending on maximum_speed property in config. So set maximum_speed according to device tree using standard usb_get_maximum_speed helper, in the same way as in other musb-based drivers.

It can be useful to limit max speed for USB peripheral. For instance, In our A40i design usb0 gadget doesn't work reliably when connected to some HS host ports, possibly due to signal integrity issues. Forcing the peripheral controller to operate in FS mode will help in this case.