### PR TITLE
wb builddeb: add wireguard-required packages to "Provides:" section

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 linux-wb (5.10.35-wb134) stable; urgency=medium
 
-  * wb builddeb: add wireguard-required packages to "Provides:" section
+  * wb builddeb: add wireguard-modules and dkms packages to Provides, Replaces, Conflicts sections
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 26 Apr 2023 13:15:21 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 linux-wb (5.10.35-wb134) stable; urgency=medium
 
-  * wb builddeb: add wireguard-modules and dkms packages to Provides, Replaces, Conflicts sections
+  * wb builddeb: add wireguard-modules package to Provides, Replaces, Conflicts sections
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 26 Apr 2023 13:15:21 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb134) stable; urgency=medium
+
+  * wb builddeb: add wireguard-required packages to "Provides:" section
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 26 Apr 2023 13:15:21 +0300
+
 linux-wb (5.10.35-wb133) stable; urgency=medium
 
   * rtl8723bu: Move powersave logs to debug.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 linux-wb (5.10.35-wb134) stable; urgency=medium
 
-  * wb builddeb: add wireguard-modules package to Provides, Replaces, Conflicts sections
+  * wb builddeb: add wireguard-modules package to "Provides:" sections
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 26 Apr 2023 13:15:21 +0300
 

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -332,10 +332,8 @@ else
 Package: $packagename
 Provides: linux-image, linux-image-2.6, linux-modules-$version, wireguard-modules (= 0.0.20210507)
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
-Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb,
-    wireguard-modules (= 0.0.20210507)
-Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image,
-    wireguard-modules (= 0.0.20210507)
+Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
+Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -330,12 +330,12 @@ else
 	cat <<EOF >> debian/control
 
 Package: $packagename
-Provides: linux-image, linux-image-2.6, linux-modules-$version, wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
+Provides: linux-image, linux-image-2.6, linux-modules-$version, wireguard-modules (= 0.0.20210507)
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
 Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb,
-    wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
+    wireguard-modules (= 0.0.20210507)
 Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image,
-    wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
+    wireguard-modules (= 0.0.20210507)
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -330,12 +330,12 @@ else
 	cat <<EOF >> debian/control
 
 Package: $packagename
-Provides: linux-image, linux-image-2.6, linux-modules-$version, linux-image-armmp, linux-image-armmp-lpae, linux-image-rt-armmp
+Provides: linux-image, linux-image-2.6, linux-modules-$version, wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
-Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, linux-image-armmp,
-	linux-image-armmp-lpae, linux-image-rt-armmp
+Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb,
+    wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
 Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image,
-	linux-image-armmp, linux-image-armmp-lpae, linux-image-rt-armmp
+    wireguard-modules (= 0.0.20210507), wireguard-dkms (= 0.0.20210507)
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -330,10 +330,12 @@ else
 	cat <<EOF >> debian/control
 
 Package: $packagename
-Provides: linux-image, linux-image-2.6, linux-modules-$version
+Provides: linux-image, linux-image-2.6, linux-modules-$version, linux-image-armmp, linux-image-armmp-lpae, linux-image-rt-armmp
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
-Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
-Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image
+Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, linux-image-armmp,
+	linux-image-armmp-lpae, linux-image-rt-armmp
+Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image,
+	linux-image-armmp, linux-image-armmp-lpae, linux-image-rt-armmp
 Suggests: $fwpackagename
 Architecture: any
 Description: Linux kernel, version $version, $wb_description


### PR DESCRIPTION
при установке, wireguard тянет с собой в зависимостях какое-то ядро (которое как минимум - занимает 100+мб места); хотя прекрасно работает на нашем ядре

добавили debian-[магии](https://wiki.debian.org/RenamingPackages) в наше ядро, чтобы оно притворялось требуемым
нужны именно Provides, Replaces и Conflicts

![2023-04-26_15-37-37](https://user-images.githubusercontent.com/25829054/234580184-aea4c480-01ef-4d81-8d2f-33b0d5dd8c99.png)
