### PR TITLE
dts: add missing wirenboard-7xx compatible strings for 7.2.x

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard720.dts
@@ -4,7 +4,7 @@
 
 / {
 	model = "Wiren Board rev. 7.2.0 (A40i)";
-	compatible = "wirenboard,wirenboard-720", "wirenboard,wirenboard-700", "allwinner,sun8i-r40";
+	compatible = "wirenboard,wirenboard-720", "wirenboard,wirenboard-72x", "wirenboard,wirenboard-700", "wirenboard,wirenboard-7xx", "allwinner,sun8i-r40";
 };
 
 &mmc0 {

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x-initram.dts
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x-initram.dts
@@ -4,7 +4,7 @@
 
 / {
 	model = "Wiren Board rev. 7.2.0 (A40i)";
-	compatible = "wirenboard,wirenboard-720-initram", "wirenboard,wirenboard-720", "wirenboard,wirenboard-700", "allwinner,sun8i-r40";
+	compatible = "wirenboard,wirenboard-720-initram", "wirenboard,wirenboard-720", "wirenboard,wirenboard-72x", "wirenboard,wirenboard-700", "wirenboard,wirenboard-7xx", "allwinner,sun8i-r40";
 };
 
 /*

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb135) stable; urgency=medium
+
+  * dts: add missing wirenboard-7xx compatible strings for 7.2.x
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 02 May 2023 21:52:50 +0600
+
 linux-wb (5.10.35-wb134) stable; urgency=medium
 
   * wb builddeb: add wireguard-modules package to "Provides:" sections


### PR DESCRIPTION
Это мешает сейчас использовать строки `wirenboard-7xx`  везде, где используется `wirenboard-720`