### PR TITLE
Feature/disable crs on eth1

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -461,12 +461,15 @@
 		"", "", "", "", /* 24 - 27 */
 		"", "", "", ""; /* 28 - 31 */
 
-    	/* w/o ECOL and ETXERR */
+	/* w/o ECOL and ETXERR (used for CAN) and
+	   w/o CRS which for some reason is kept as output by the A40i GMAC,
+	   which, in turn, leads to wrong LED mode conifguration on IP101 phy.
+	 */
 	gmac_mii_pins_reduced: gmac-mii-pins-reduced {
 		pins = "PA0", "PA1", "PA2", "PA3",
 			"PA4", "PA5", "PA6", "PA7",
 			"PA8", "PA9", "PA10", "PA11", "PA12",
-			"PA13", "PA14", "PA15";
+			"PA13", "PA14";
 		drive-strength = <40>;
 
 		function = "gmac";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb135) stable; urgency=medium
+
+  * fix LED mode on second ethernet
+
+ -- Evgeny Boger <boger@wirenboard.com>  Tue, 02 May 2023 19:00:50 +0300
+
 linux-wb (5.10.35-wb134) stable; urgency=medium
 
   * wb builddeb: add wireguard-modules package to "Provides:" sections


### PR DESCRIPTION
For some reason A40i GMAC keep CRS pin as output even while
in MII mode. So don't attach this pin to the GMAC.

CRS pin is sampled on reset by IP101GRI phy to configure LED mode.
