### PR TITLE
wb builddeb: add wireguard-required packages to "Provides:" section

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb133+wb101) stable; urgency=medium
+
+  * wb builddeb: add wireguard-modules package to "Provides:" sections
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 29 May 2023 14:16:31 +0600
+
 linux-wb (5.10.35-wb133+wb100) stable; urgency=medium
 
   * wb7: enable exfat support

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -330,7 +330,7 @@ else
 	cat <<EOF >> debian/control
 
 Package: $packagename
-Provides: linux-image, linux-image-2.6, linux-modules-$version
+Provides: linux-image, linux-image-2.6, linux-modules-$version, wireguard-modules (= 0.0.20210507)
 Breaks: linux-image-4.9.22-$wb_target (<< $packageversion)
 Replaces: linux-image-4.9.22-$wb_target (<< $packageversion), linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb
 Conflicts: linux-image-4.1.15-imxv5-x0.1, linux-image-4.9.6-wb, wb-configs (<= 1.72), wb-hwconf-manager (<< 1.41.0~~), linux-image


### PR DESCRIPTION
backport of #129