### PR TITLE
wb7: disable microsd card detect gpio

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -859,7 +859,7 @@
 /* microSD */
 &mmc0 {
 	bus-width = <4>;
-	cd-gpios = <PIN_PC 5 GPIO_ACTIVE_LOW>;
+	broken-cd = <1>;
 	status = "okay";
 
 	vqmmc-supply = <&vcc_sd>;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb148) stable; urgency=medium
+
+  * wb7: disable microsd card detect gpio (it is broken on some boards)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 20 Sep 2023 15:52:20 +0600
+
 linux-wb (5.10.35-wb147) stable; urgency=medium
 
   * wb741 dts: fix "V_OUT ON" gpio name


### PR DESCRIPTION
На некоторых платах оказался слот microsd сомнительного качества, и для их корректной работы приходится отказываться от card detect через gpio.