### PR TITLE
Feature/sd detect backport

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -856,7 +856,7 @@
 /* microSD */
 &mmc0 {
 	bus-width = <4>;
-	cd-gpios = <PIN_PC 5 GPIO_ACTIVE_LOW>;
+	broken-cd = <1>;
 	status = "okay";
 
 	vqmmc-supply = <&vcc_sd>;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb120+wb102) stable; urgency=medium
+
+  * wb7: disable microsd card detect gpio (it is broken on some boards)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 28 Sep 2023 13:54:34 +0300
+
 linux-wb (5.10.35-wb120+wb101) stable; urgency=medium
 
   * wb: more robust 1-wire readings. Fix regression in wb 5.10 kernel.


### PR DESCRIPTION
На производстве на специальной версии контроллеров снова вылезла проблема с sd

решили бекпортировать и в 2207