### PR TITLE
wb74: disable microsd card detect gpio

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
@@ -990,7 +990,7 @@
 /* microSD */
 &mmc0 {
 	bus-width = <4>;
-	cd-gpios = <PIN_PC 5 GPIO_ACTIVE_LOW>;
+	broken-cd = <1>;
 	status = "okay";
 
 	vqmmc-supply = <&vcc_sd>;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb153) stable; urgency=medium
+
+  * wb74: disable microsd card detect gpio (it is broken on some boards)
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Oct 2023 13:58:00 +0400
+
 linux-wb (5.10.35-wb152) stable; urgency=medium
 
   * wbec: fix stack overwrite in sysfs read resulting in junk in fwrev


### PR DESCRIPTION
Backport of https://github.com/wirenboard/linux/pull/151 to 74x.