### PR TITLE
wb7x: enable USB regulator on boot to fix some USB flash drives detection

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -48,6 +48,7 @@
 			regulator-name = "usb0_vbus";
 			regulator-min-microvolt = <5000000>;
 			regulator-max-microvolt = <5000000>;
+			regulator-boot-on;
 
 			gpio = <PIN_PE 0 GPIO_ACTIVE_HIGH>;
 			enable-active-high;

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
@@ -53,6 +53,7 @@
 
 			gpio = <PIN_PE 0 GPIO_ACTIVE_HIGH>;
 			enable-active-high;
+			regulator-boot-on;
 		};
 
 		/* USB Wi-Fi is directly connected to SoC, power supply is

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb154) stable; urgency=medium
+
+  * wb7x: enable USB regulator on boot to fix some USB flash drives detection
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 02 Nov 2023 21:20:22 +0600
+
 linux-wb (5.10.35-wb153) stable; urgency=medium
 
   * wb74: disable microsd card detect gpio (it is broken on some boards)


### PR DESCRIPTION
Чинит проблему с некоторыми флешками, которые неверно определяются при запуске. Конкретная причина до сих пор непонятна, но кажется, что это связано с последовательностью запуска USB-контроллера и подачей питания на устройство.

Проблема чинится стабильно (ни одной неудачи на двух контроллерах с разными глючными флешками), ранее работавшие флешки не ломаются.

Особенно актуален этот фикс для бутлета, потому что он не видел файлы на флешке и не мог обновиться с неё.