### PR TITLE
dts: wb74x: fix 1-Wire pins

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
@@ -715,12 +715,12 @@
 
 	/* W1-W2 */
 	pinctrl_w1_gpio: w1-gpio-pins {
-		pins = "PB13", "PH2";
+		pins = "PH2", "PI0";
 		function = "gpio_in";
 	};
 
 	pinctrl_w2_gpio: w2-gpio-pins {
-		pins = "PE3", "PI15";
+		pins = "PI17", "PI1";
 		function = "gpio_in";
 	};
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb155) stable; urgency=medium
+
+  * Fix 1-Wire pin numbers for Wiren Board 7.4+
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Sat, 11 Nov 2023 00:16:41 +0600
+
 linux-wb (5.10.35-wb154) stable; urgency=medium
 
   * wb7x: dts: fix microsd card power in bootlet on 7.3+ boards


### PR DESCRIPTION
Забыли в момент выпуска wb74 прописать правильные пины для 1-wire (а они там переехали), из-за этого при перенастройке 1-wire отключается питание периферии. Починил, связанный PR в hwconf-manager ниже.