### PR TITLE
wb7x: enable USB regulator on boot to fix some USB flash drives detection (rebase)

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -49,6 +49,14 @@
 			regulator-min-microvolt = <5000000>;
 			regulator-max-microvolt = <5000000>;
 
+			// WB7 has problems with some USB drives which are detected incorrectly on boot.
+			// *HCI unbind+bind helps but it's not convenient (especially during normal OS boot).
+			// Suddenly enabling power at boot time fixes this pretty well.
+			// This issue still is not fully understood, maybe some more debugging is needed.
+			//
+			// @lostpoint and @webconn have some 'broken' USB drives if you want to test it later.
+			regulator-boot-on;
+
 			gpio = <PIN_PE 0 GPIO_ACTIVE_HIGH>;
 			enable-active-high;
 		};

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
@@ -51,6 +51,14 @@
 			regulator-min-microvolt = <5000000>;
 			regulator-max-microvolt = <5000000>;
 
+			// WB7 has problems with some USB drives which are detected incorrectly on boot.
+			// *HCI unbind+bind helps but it's not convenient (especially during normal OS boot).
+			// Suddenly enabling power at boot time fixes this pretty well.
+			// This issue still is not fully understood, maybe some more debugging is needed.
+			//
+			// @lostpoint and @webconn have some 'broken' USB drives if you want to test it later.
+			regulator-boot-on;
+
 			gpio = <PIN_PE 0 GPIO_ACTIVE_HIGH>;
 			enable-active-high;
 		};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb156) stable; urgency=medium
+
+  * wb7x: enable USB regulator on boot to fix some USB flash drives detection
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 21 Nov 2023 19:05:38 +0600
+
 linux-wb (5.10.35-wb155) stable; urgency=medium
 
   * Fix 1-Wire pin numbers for Wiren Board 7.4+


### PR DESCRIPTION
rebase of #161