### PR TITLE
Feature/mcp23s08 errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb158) stable; urgency=medium
+
+  * pinctrl-mcp23s08: mcp_read: pass error of regmap_read
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 19 Dec 2023 10:11:22 +0300
+
 linux-wb (5.10.35-wb157) stable; urgency=medium
 
   * rtl8733bu: log association rejection messages as warnings 

--- a/drivers/pinctrl/pinctrl-mcp23s08.c
+++ b/drivers/pinctrl/pinctrl-mcp23s08.c
@@ -297,7 +297,7 @@ static int mcp23s08_get(struct gpio_chip *chip, unsigned offset)
 	/* REVISIT reading this clears any IRQ ... */
 	ret = mcp_read(mcp, MCP_GPIO, &status);
 	if (ret < 0)
-		status = 0;
+		status = ret;
 	else {
 		mcp->cached_gpio = status;
 		status = !!(status & (1 << offset));


### PR DESCRIPTION
Проблема: если wbio-модуль физически отсоединён от wb - никаких ругательств со стороны ядра не поступает => не можем понять, вставлен модуль или нет

раскопал весь gpio-стек и похоже, драйвер проглатывает ошибку там, где вроде как не должен. Зачем так сделано - непонятно; есть [старый патч](https://lkml.org/lkml/2007/11/9/143); переписки по нему не нашел.

С нашей стороны ничего не поломалось; результат (вытащил wbio):
![image](https://github.com/wirenboard/linux/assets/25829054/f57c4dd9-d8b3-4ad4-b422-c179f238c6d4)
нас устраивает