### PR TITLE
Fix wbmz4-supercap values at full charge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb159) stable; urgency=medium
+
+  * Fix supercap zero values after startup in case of full charge
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Fri, 22 Dec 2023 10:32:46 +0300
+
 linux-wb (5.10.35-wb158) stable; urgency=medium
 
   * rtl8733bu: move some log messages to info debug level

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -628,7 +628,7 @@ static int axp20x_power_probe(struct platform_device *pdev)
 
 	// Enable battery detection function to work with wbmz-battery
 	rc = regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
-				  AXP20X_OFF_CTRL_BAT_DET, 0xF);
+				  AXP20X_OFF_CTRL_BAT_DET, 0xFF);
 	if (rc) {
 		dev_err(dev,
 			"Failed to enable battery detection function");

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -626,7 +626,6 @@ static int axp20x_power_probe(struct platform_device *pdev)
 
 	axp20x_batt->regmap = dev_get_regmap(pdev->dev.parent, NULL);
 
-	// Enable battery detection function to work with wbmz-battery
 	rc = regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
 				  AXP20X_OFF_CTRL_BAT_DET, 0xFF);
 	if (rc) {
@@ -723,7 +722,6 @@ static int axp20x_power_remove(struct platform_device *pdev)
 {
 	struct axp20x_batt_ps *axp20x_batt = platform_get_drvdata(pdev);
 
-	// Disable battery detection function to work with wbmz-supercap
 	return regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
 				  AXP20X_OFF_CTRL_BAT_DET, 0);
 }

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -628,18 +628,12 @@ static int axp20x_power_probe(struct platform_device *pdev)
 
 	// Enable battery detection function to work with wbmz-battery
 	rc = regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
-				  AXP20X_OFF_CTRL_BAT_DET, 1);
+				  AXP20X_OFF_CTRL_BAT_DET, 0xF);
 	if (rc) {
 		dev_err(dev,
 			"Failed to enable battery detection function");
 		return rc;
-	}
-
-	if (regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
-				  AXP20X_OFF_CTRL_BAT_DET, 1) == -1) {
-
-				  }
-	
+	}	
 
 	axp20x_batt->batt_v = devm_iio_channel_get(&pdev->dev, "batt_v");
 	if (IS_ERR(axp20x_batt->batt_v)) {

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -57,6 +57,8 @@
 
 #define AXP20X_V_OFF_MASK		GENMASK(2, 0)
 
+#define AXP20X_OFF_CTRL_BAT_DET		BIT(6)
+
 struct axp20x_batt_ps;
 
 struct axp_data {
@@ -610,6 +612,7 @@ static int axp20x_power_probe(struct platform_device *pdev)
 	struct power_supply_battery_info info;
 	struct device *dev = &pdev->dev;
 	u32 tmp;
+	int rc;
 
 	if (!of_device_is_available(pdev->dev.of_node))
 		return -ENODEV;
@@ -620,6 +623,23 @@ static int axp20x_power_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	axp20x_batt->dev = &pdev->dev;
+
+	axp20x_batt->regmap = dev_get_regmap(pdev->dev.parent, NULL);
+
+	// Enable battery detection function to work with wbmz-battery
+	rc = regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
+				  AXP20X_OFF_CTRL_BAT_DET, 1);
+	if (rc) {
+		dev_err(dev,
+			"Failed to enable battery detection function");
+		return rc;
+	}
+
+	if (regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
+				  AXP20X_OFF_CTRL_BAT_DET, 1) == -1) {
+
+				  }
+	
 
 	axp20x_batt->batt_v = devm_iio_channel_get(&pdev->dev, "batt_v");
 	if (IS_ERR(axp20x_batt->batt_v)) {
@@ -644,7 +664,6 @@ static int axp20x_power_probe(struct platform_device *pdev)
 		return PTR_ERR(axp20x_batt->batt_dischrg_i);
 	}
 
-	axp20x_batt->regmap = dev_get_regmap(pdev->dev.parent, NULL);
 	platform_set_drvdata(pdev, axp20x_batt);
 
 	psy_cfg.drv_data = axp20x_batt;
@@ -706,8 +725,18 @@ static int axp20x_power_probe(struct platform_device *pdev)
 	return 0;
 }
 
+static int axp20x_power_remove(struct platform_device *pdev)
+{
+	struct axp20x_batt_ps *axp20x_batt = platform_get_drvdata(pdev);
+
+	// Disable battery detection function to work with wbmz-supercap
+	return regmap_update_bits(axp20x_batt->regmap, AXP20X_OFF_CTRL,
+				  AXP20X_OFF_CTRL_BAT_DET, 0);
+}
+
 static struct platform_driver axp20x_batt_driver = {
 	.probe    = axp20x_power_probe,
+	.remove   = axp20x_power_remove,
 	.driver   = {
 		.name  = "axp20x-battery-power-supply",
 		.of_match_table = axp20x_battery_ps_id,


### PR DESCRIPTION
В случае загрузки контроллера при полном заряде суперкапа, pmic выдавал нулевые значения напряжения, из за этого все показатели суперкапа были нулевые. Плохо работает функция автоматического определения наличия батареи, при полном заряде суперкапа pmic считает что батареи нет.
Сделала в стандартном драйвере батарейки поправку: при добавлении устройства поднимается бит автоматического обнаружения (чтобы для литиевых батарей все было по старому), а при удалении сбрасывается, так как предполагается что после этого включат драйвер edlc для суперкапа.