### PR TITLE
make wb7x-factory-bootlet not work as regular bootlet

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-wb (5.10.35-wb161) stable; urgency=medium
+
+  * scripts: make wb7x-factory-bootlet not work as regular bootlet; no functional
+    changes to kernel
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 17 Jan 2024 20:28:33 +0600
+
 linux-wb (5.10.35-wb160) stable; urgency=medium
 
   * pinctrl-mcp23s08: mcp_read: pass error of regmap_read

--- a/scripts/package/wb/do_build_deb.sh
+++ b/scripts/package/wb/do_build_deb.sh
@@ -65,6 +65,16 @@ make_bootlet_deb() {
     local BOOTLET_DIR="$DEBDIR/var/lib/wb-image-update"
     local TARGET_NAME="${KERNEL_FLAVOUR%-bootlet}"
     local PACKAGE_NAME="wb-bootlet-$TARGET_NAME"
+    local EXTRA_ARGS=()
+
+    if [ "$PROVIDES_BOOTLET_FOR_FITS" = "y" ]; then
+        EXTRA_ARGS=("--provides" "wb-bootlet" "--replaces" "wb-bootlet" "--conflicts" "wb-bootlet")
+    fi
+
+    if [ -n "$BOOTLET_DEPS" ]; then
+        EXTRA_ARGS+=("--depends" "$BOOTLET_DEPS")
+    fi
+
     mkdir -p "$BOOTLET_DIR"
 
     cp "$KBUILD_OUTPUT/arch/arm/boot/zImage" "$BOOTLET_DIR/zImage"
@@ -78,10 +88,7 @@ make_bootlet_deb() {
         --url "https://github.com/wirenboard/linux" \
         --deb-no-default-config-files \
         --deb-priority optional \
-        --provides "wb-bootlet" \
-        --replaces "wb-bootlet" \
-        --conflicts "wb-bootlet" \
-        --depends "$BOOTLET_DEPS" \
+        "${EXTRA_ARGS[@]}" \
         -C "$DEBDIR" .
 }
 

--- a/scripts/package/wb/version.sh
+++ b/scripts/package/wb/version.sh
@@ -35,6 +35,7 @@ setup_kernel_vars() {
 			KERNEL_DEFCONFIG=imx6_wirenboard_initramfs_defconfig
 			BOOTLET_DTB=imx6ul-wirenboard6x-init.dtb
 			BOOTLET_DEPS=linux-image-wb6
+			PROVIDES_BOOTLET_FOR_FITS=y
 			KDEB_WBDESC="Wiren Board 6 (bootlet)"
 			;;
 		wb7)
@@ -52,6 +53,7 @@ setup_kernel_vars() {
 			KERNEL_DEFCONFIG=wirenboard7_initramfs_defconfig
 			BOOTLET_DTB=sun8i-r40-wirenboard72x-initram.dtb
 			BOOTLET_DEPS=linux-image-wb7
+			PROVIDES_BOOTLET_FOR_FITS=y
 			KDEB_WBDESC="Wiren Board 7 (bootlet)"
 			;;
 		wb7x-factory-bootlet)
@@ -60,6 +62,7 @@ setup_kernel_vars() {
 			DEBARCH=armhf
 			KERNEL_DEFCONFIG=wirenboard7_initramfs_defconfig
 			BOOTLET_DTB=sun8i-r40-wirenboard72x-factory.dtb
+			PROVIDES_BOOTLET_FOR_FITS=  # used in production, no need to install it on boards
 			BOOTLET_DEPS=
 			KDEB_WBDESC="Wiren Board 7 (factory bootlet)"
 			;;
@@ -92,5 +95,5 @@ setup_kernel_vars() {
 			return 1
 			;;
 	esac
-	export DEBARCH KERNEL_DEFCONFIG KDEB_WBFLAVOUR_DESC CROSS_COMPILE BOOTLET_DTB INITRAMFS_VERSION KDEB_WBDESC BOOTLET_DEPS
+	export DEBARCH KERNEL_DEFCONFIG KDEB_WBFLAVOUR_DESC CROSS_COMPILE BOOTLET_DTB INITRAMFS_VERSION KDEB_WBDESC BOOTLET_DEPS PROVIDES_BOOTLET_FOR_FITS
 }


### PR DESCRIPTION
После https://github.com/wirenboard/wb-utils/pull/146 в FIT-образы testing для wb6 стали попадать заводские бутлеты для wb7, потому что они подходили по условиям (`provides: wb-bootlet` и не ломали зависимостей от ядра). 

Релизы не были затронуты, т.к. там в репозиториях лежат только нужные пакеты, нет бутлетов от чужих таргетов.

Сделал так, чтобы factory-бутлет для wb7 нельзя было поставить в rootfs через зависимость от wb-bootlet.