### PR TITLE
dts: enables support for device-tree overlays for wb8

### DIFF
--- a/arch/arm64/boot/dts/allwinner/Makefile
+++ b/arch/arm64/boot/dts/allwinner/Makefile
@@ -46,3 +46,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
 dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
 dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-transpeed-8k618-t.dtb
 dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-wirenboard8xx.dtb
+
+# Enables support for device-tree overlays
+DTC_FLAGS_sun50i-h616-wirenboard8xx := -@


### PR DESCRIPTION
> When compiled with the -@ or --symbols option, a .dtb will contain a `__symbols__` node that can be used by the system to resolve references to device nodes by any device tree overlays.

### Before
```sh
$ dmesg | grep -B2 "Failed to create overlay"
[   13.397702] OF: resolver: no symbols in root of device tree.
[   13.403413] OF: resolver: overlay phandle fixup failed: -22
[   13.409001] create_overlay: Failed to create overlay (err=-22)
[   13.520173] OF: resolver: no symbols in root of device tree.
[   13.525866] OF: resolver: overlay phandle fixup failed: -22
[   13.531569] create_overlay: Failed to create overlay (err=-22)
[   14.066661] OF: resolver: no symbols in root of device tree.
[   14.072409] OF: resolver: overlay phandle fixup failed: -22
[   14.078010] create_overlay: Failed to create overlay (err=-22)
$ ls /proc/device-tree/__symbols__
ls: cannot access '/proc/device-tree/__symbols__': No such file or directory
```

### After
`/proc/device-tree/__symbols__` exists and no create_overlay errors in dmeg.