### PR TITLE
wb8: add compatibility with wirenboard,wirenboard-84x

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard843.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard843.dts
@@ -3,7 +3,7 @@
 
 / {
 	model = "Wiren Board rev. 8.4.3 (T507)";
-	compatible = "wirenboard,wirenboard-843", "wirenboard,wirenboard-8xx", "allwinner,sun50i-h616";
+	compatible = "wirenboard,wirenboard-843", "wirenboard,wirenboard-84x", "wirenboard,wirenboard-8xx", "allwinner,sun50i-h616";
 
 	a1_volt: a1-volt {
 		compatible = "voltage-divider";


### PR DESCRIPTION
увидел, что hwconf смотрит в wirenboard,wirenboard-84x

выглядит логично => почему бы не добавить