### PR TITLE
wb8 dts: add mod1_dummy node to provide compatibility with wb-hwconf-…

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
@@ -444,6 +444,11 @@
 		status = "okay";
 	};
 
+	mod1_dummy: mod1_dummy {
+		// only to provide wb-hwconf-manager compatibility
+		status = "disabled";
+	};
+
 	soc {
 		dma: dma-controller@3002000 {
 			compatible = "allwinner,sun50i-h6-dma";


### PR DESCRIPTION
…manager

вытащил dummy-ноду для mod1 wb8