### PR TITLE
AXP driver fixup for WBMZ5-BATTERY support

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
@@ -357,17 +357,16 @@
 		#size-cells = <0>;
 		status = "okay";
 
-		axp22x: pmic@34 {
+		axp22x_wbmz5: pmic@34 {
 			compatible = "x-powers,axp221";
 			reg = <0x34>;
+
+			wirenboard,wbmz-pmic;  // keeps only ADC and battery sysfs nodes to fix conflict with main PMIC
 
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
-			ac_power_supply: ac-power-supply {
-				compatible = "x-powers,axp221-ac-power-supply";
-				status = "okay";
-			};
+			status = "disabled";
 
 			axp_adc: adc {
 				compatible = "x-powers,axp221-adc";
@@ -382,11 +381,6 @@
 				// it's ~40C conservative high temperature limit.
 				// to be overrided by battery overlay
 				x-powers,charge-high-temp-microvolt = <499200>;
-			};
-
-			usb_power_supply: usb_power_supply {
-				compatible = "x-powers,axp221-usb-power-supply";
-				status = "okay";
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
@@ -366,7 +366,7 @@
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
-			status = "disabled";
+			status = "okay";
 
 			axp_adc: adc {
 				compatible = "x-powers,axp221-adc";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb7) stable; urgency=medium
+
+  * wb8: fix WBMZ5-BATTERY by adding special AXP driver mode
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 13 Jun 2024 19:34:37 +0500
+
 linux-wb (6.8.0-wb6) stable; urgency=medium
 
   * wb8 dts: rename gpios

--- a/drivers/mfd/axp20x.c
+++ b/drivers/mfd/axp20x.c
@@ -899,6 +899,16 @@ static const struct mfd_cell axp221_cells[] = {
 	},
 };
 
+static const struct mfd_cell axp221_wbmz_pmic_cells[] = {
+	{
+		.name		= "axp22x-adc",
+		.of_compatible	= "x-powers,axp221-adc",
+	}, {
+		.name		= "axp20x-battery-power-supply",
+		.of_compatible	= "x-powers,axp221-battery-power-supply",
+	},
+};
+
 static const struct mfd_cell axp223_cells[] = {
 	{
 		.name		= "axp20x-gpio",
@@ -1157,8 +1167,16 @@ int axp20x_match_device(struct axp20x_dev *axp20x)
 		axp20x->regmap_irq_chip = &axp20x_regmap_irq_chip;
 		break;
 	case AXP221_ID:
-		axp20x->nr_cells = ARRAY_SIZE(axp221_cells);
-		axp20x->cells = axp221_cells;
+		if (of_property_read_bool(axp20x->dev->of_node,
+					  "wirenboard,wbmz-pmic")) {
+			axp20x->nr_cells = ARRAY_SIZE(axp221_wbmz_pmic_cells);
+			axp20x->cells = axp221_wbmz_pmic_cells;
+			nr_cells_no_irq = ARRAY_SIZE(axp221_wbmz_pmic_cells);
+			cells_no_irq = axp221_wbmz_pmic_cells;
+		} else {
+			axp20x->nr_cells = ARRAY_SIZE(axp221_cells);
+			axp20x->cells = axp221_cells;
+		}
 		axp20x->regmap_cfg = &axp22x_regmap_config;
 		axp20x->regmap_irq_chip = &axp22x_regmap_irq_chip;
 		break;

--- a/drivers/mfd/axp20x.c
+++ b/drivers/mfd/axp20x.c
@@ -879,7 +879,7 @@ static const struct mfd_cell axp221_cells[] = {
 		.num_resources	= ARRAY_SIZE(axp22x_pek_resources),
 		.resources	= axp22x_pek_resources,
 	}, {
-		.name		= "axp221-regulator",
+		.name		= "axp20x-regulator",
 	}, {
 		.name		= "axp22x-adc",
 		.of_compatible	= "x-powers,axp221-adc",


### PR DESCRIPTION
В WB8 с WBMZ5-BATTERY в системе присутствуют два AXP PMIC, которые используют общий драйвер `axp20x`. Этот драйвер не очень расчитан на присутствие в системе двух PMIC, там возникает конфликт при добавлении нод `axp20x-regulator` в sysfs. Плюс, `axp221`  требует прерывание и без него запускаться не хочет, при том что в режиме fuel gauge нам прерывание не нужно и на плате оно физически не разведено.

Раньше поддержка WBMZ5-BATTERY работала через переименование ноды регулятора у `axp221` (это был грязный хак на время разработки) и брала какой-то рандомный gpio в качестве прерывания. Перед выпуском WB8 я на всякий случай убрал эту ножку прерывания, из-за чего axp221 перестал добавляться в ядро.

Сейчас я сделал в драйвере mfd axp20x отдельный набор sysfs нод, который включается при наличии специальной записи в dts только для wbmz5. Мне кажется это более чистым решением, хотя всё ещё не идеальным.

Также откатил переименование axp20x-regulator в `axp221`, которое сделал ранее.

Проверил на WB8 с батарейкой.