### PR TITLE
wb8 dts: add 1-Wire pins

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8xx.dtsi
@@ -772,6 +772,17 @@
 		function = "uart1";
 	};
 
+	/* W1-W2 */
+	pinctrl_w1_gpio: w1-gpio-pins {
+		pins = "PD24", "PG8";
+		function = "gpio_in";
+	};
+
+	pinctrl_w2_gpio: w2-gpio-pins {
+		pins = "PE11", "PE21";
+		function = "gpio_in";
+	};
+
 	/* MOD2 */
 	pinctrl_mod2_i2c_gpio: mod2-txrx-i2c-pins {
 		pins = "PI13", "PI14";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb14) stable; urgency=medium
+
+  * wb8 dts: add 1-Wire pins
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 12 Jul 2024 19:05:00 +0400
+
 linux-wb (6.8.0-wb13) stable; urgency=medium
 
   * mfd-wbec: fix power-off handler (switch to the sys-off handler API)


### PR DESCRIPTION
```sh
$ ls /sys/firmware/devicetree/base/__symbols__ | grep "pinctrl_w1_gpio\|pinctrl_w2_gpio"
pinctrl_w1_gpio
pinctrl_w2_gpio
```

Ref https://github.com/wirenboard/linux/commit/abba61af16ba0ff047b14ce27023844444833450