### PR TITLE
Linux 6.8 rebase: WB8 ethernet patches

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
@@ -511,6 +511,19 @@
 			};
 		};
 
+		emac1: ethernet@5030000 {
+			compatible = "allwinner,sun50i-t507-emac1";
+			reg = <0x05030000 0x10000>;
+			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "macirq";
+			clocks = <&ccu CLK_BUS_EMAC1>;
+			clock-names = "stmmaceth";
+			resets = <&ccu RST_BUS_EMAC1>;
+			reset-names = "stmmaceth";
+			syscon = <&syscon>;
+			status = "disabled";
+		};
+
 		usbotg: usb@5100000 {
 			compatible = "allwinner,sun50i-h616-musb",
 				     "allwinner,sun8i-h3-musb";

--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
@@ -86,6 +86,13 @@ static const struct reg_field sun8i_syscon_reg_field = {
 	.msb = 31,
 };
 
+/* In T507 there is a second register for EMAC1 clock */
+static const struct reg_field sun50i_t507_emac1_syscon_reg_field = {
+	.reg = 0x34,
+	.lsb = 0,
+	.msb = 31,
+};
+
 /* EMAC clock register @ 0x164 in the CCU address range */
 static const struct reg_field sun8i_ccu_reg_field = {
 	.reg = 0x164,
@@ -136,6 +143,17 @@ static const struct emac_variant emac_variant_a64 = {
 	.support_mii = true,
 	.support_rmii = true,
 	.support_rgmii = true,
+	.rx_delay_max = 31,
+	.tx_delay_max = 7,
+};
+
+static const struct emac_variant emac_variant_t507_emac1 = {
+	.default_syscon_value = 0,
+	.syscon_field = &sun50i_t507_emac1_syscon_reg_field,
+	.soc_has_internal_phy = false,
+	.support_mii = true,
+	.support_rmii = true,
+	.support_rgmii = false,
 	.rx_delay_max = 31,
 	.tx_delay_max = 7,
 };
@@ -1343,6 +1361,8 @@ static const struct of_device_id sun8i_dwmac_match[] = {
 		.data = &emac_variant_a64 },
 	{ .compatible = "allwinner,sun50i-h6-emac",
 		.data = &emac_variant_h6 },
+	{ .compatible = "allwinner,sun50i-t507-emac1",
+		.data = &emac_variant_t507_emac1 },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, sun8i_dwmac_match);


### PR DESCRIPTION
Первый PR из серии, в которой мы проведём ревью всех изменений в ядро 6.8 для Wiren Board 8.

Разделил коммит https://github.com/wirenboard/linux/commit/5d2933d557fc1e4ac2d58a2fc670ae8c1abc1f5c на логические фрагменты, часть из которых потом можно было бы выбросить по мере добавления недостающих в апстрим.

Внешний клок для mdio-gpio и отключение EMAC reset timeout, на мой взгляд - грязноватые хаки, которые вряд ли примут в апстрим. Без них, правда, у меня пока не получилось завести ethernet (расписал подробнее в описании коммитов).