### PR TITLE
Linux 6.8 rebase: WBEC driver

### DIFF
--- a/Documentation/devicetree/bindings/gpio/wirenboard,wbec-gpio.yaml
+++ b/Documentation/devicetree/bindings/gpio/wirenboard,wbec-gpio.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+# Copyright 2019 Bootlin
+%YAML 1.2
+---
+$id: "http://devicetree.org/schemas/gpio/wirenboard,wbec-gpio.yaml#"
+$schema: "http://devicetree.org/meta-schemas/core.yaml#"
+
+title: Wiren Board Embedded Controller GPIO Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  The WB EC GPIO describes the GPIO block included in the WB EC.
+
+  The driver exposes GPIOs from the WB EC.
+  For GPIO description look at WB EC firmware.
+  Current GPIOs are:
+  - [3:0] - A1-A4 inputs
+  - [4] - V_OUT control
+  - [5] - WBMZ Status
+
+properties:
+  compatible:
+    const: wirenboard,wbec-gpio
+
+  reg:
+    const: 0
+
+  "#gpio-cells":
+    const: 2
+
+  gpio-controller: true
+
+  ngpios:
+    minimum: 1
+    description:
+      Number of GPIOs
+
+  gpio-line-names:
+    minItems: 1
+
+required:
+  - compatible
+  - reg
+  - "#gpio-cells"
+  - gpio-controller
+  - ngpios
+
+additionalProperties: false
+
+examples:
+  - |
+    wbec_gpio: wbec-gpio@0 {
+      compatible = "wirenboard,wbec-gpio";
+      reg = <0>;
+
+      gpio-controller;
+      #gpio-cells = <2>;
+      ngpios = <6>;
+      gpio-line-names = "EC A1", "EC A2", "EC A3", "EC A4", "EC V OUT", "EC WBMZ STATUS";
+    };

--- a/Documentation/devicetree/bindings/iio/adc/wirenboard,wbec-adc.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/wirenboard,wbec-adc.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/adc/wirenboard,wbec-adc.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller ADC Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  The WB EC ADC describes the ADC block included in the WB EC.
+  The driver produces next IIO channels:
+  [0] - Voltage on Vin terminal in mV
+  [1] - Voltage on 3.3V bus in mV
+  [2] - Voltage on 5V bus in mV
+  [3] - Voltage on USB debug console in mV
+  [4] - Voltage on USB debug network in mV
+  [5] - Board temperature in deg C
+  [6..11] - ADC1..ADC6 channels in mV after divider (on WB EC pin)
+
+properties:
+  compatible:
+    const: wirenboard,wbec-adc
+
+  reg:
+    const: 0
+
+  "#io-channel-cells":
+    const: 1
+
+required:
+  - compatible
+  - reg
+  - "#io-channel-cells"
+
+additionalProperties: false
+
+examples:
+  - |
+    wbec_adc: wbec-adc@0 {
+      compatible = "wirenboard,wbec-adc";
+      reg = <0>;
+      #io-channel-cells = <1>;
+    };
+...

--- a/Documentation/devicetree/bindings/input/wirenboard,wbec-pwrkey.yaml
+++ b/Documentation/devicetree/bindings/input/wirenboard,wbec-pwrkey.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/input/wirenboard,wbec-pwrkey.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller Power Button Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  Enables Power Button support on the Wiren Board Embedded Controller.
+
+properties:
+  compatible:
+    const: wirenboard,wbec-pwrkey
+
+  reg:
+    const: 0
+
+required:
+  - compatible
+  - reg
+
+additionalProperties: false
+
+examples:
+  - |
+    wbec-pwrkey@0 {
+      compatible = "wirenboard,wbec-pwrkey";
+      reg = <0>;
+    };
+...

--- a/Documentation/devicetree/bindings/mfd/wirenboard,wbec.yaml
+++ b/Documentation/devicetree/bindings/mfd/wirenboard,wbec.yaml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/mfd/wirenboard,wbec.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  Wiren Board Embedded Controller (WB EC, wbec) is an MCU with special firmware
+  installed on Wiren Board Automation Controller since HW revision 7.4.
+  WB EC is MFD device and provides such function as RTC, WDT, GPIO, ADC, PWRKEY.
+
+properties:
+  compatible:
+    const: wirenboard,wbec
+
+  reg:
+    const: 0
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 0
+
+  spi-max-frequency:
+    maximum: 1000000
+    description: |
+      Maximum frequency for SPI bus.
+
+  wakeup-source: true
+
+required:
+  - compatible
+  - reg
+  - "#address-cells"
+  - "#size-cells"
+  - wakeup-source
+  - spi-max-frequency
+
+additionalProperties: false
+
+examples:
+  - |
+    &spi2 {
+      pinctrl-0 = <&spi2_pb_pins>,
+                  <&spi2_cs0_pb_pin>;
+      pinctrl-names = "default";
+      status = "okay";
+
+      wbec: wbec@0 {
+        spi-max-frequency = <1000000>;
+
+        compatible = "wirenboard,wbec";
+        reg = <0>;
+        status = "okay";
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        wakeup-source;
+
+        wbec_gpio: wbec-gpio@0 {
+          compatible = "wirenboard,wbec-gpio";
+          reg = <0>;
+
+          gpio-controller;
+          #gpio-cells = <2>;
+          ngpios = <5>;
+          gpio-line-names = "EC A1", "EC A2", "EC A3", "EC A4", "EC V OUT";
+        };
+
+        wbec_adc: wbec-adc@0 {
+          compatible = "wirenboard,wbec-adc";
+          reg = <0>;
+          #io-channel-cells = <1>;
+        };
+
+        vin: wbec-power@0 {
+          compatible = "wirenboard,wbec-power";
+          reg = <0>;
+        };
+      };
+    };

--- a/Documentation/devicetree/bindings/power/wirenboard,wbec-power.yaml
+++ b/Documentation/devicetree/bindings/power/wirenboard,wbec-power.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/power/wirenboard,wbec-power.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller Power Supply Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  The driver provides power supply class for the Wiren Board.
+
+properties:
+  compatible:
+    const: wirenboard,wbec-power
+
+  reg:
+    const: 0
+
+required:
+  - compatible
+  - reg
+
+additionalProperties: false
+
+examples:
+  - |
+    vin: wbec-power@0 {
+      compatible = "wirenboard,wbec-power";
+      reg = <0>;
+    };
+...

--- a/Documentation/devicetree/bindings/rtc/wirenboard,wbec-rtc.yaml
+++ b/Documentation/devicetree/bindings/rtc/wirenboard,wbec-rtc.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/rtc/wirenboard,wbec-rtc.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller RTC Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  Enables access to the Real Time Clock (RTC) on the Wiren Board Embedded Controller.
+
+properties:
+  compatible:
+    const: wirenboard,wbec-rtc
+
+  reg:
+    const: 0
+
+  wakeup-source: true
+
+required:
+  - compatible
+  - reg
+  - wakeup-source
+
+additionalProperties: false
+
+examples:
+  - |
+    rtc_onboard: wbec-rtc@0 {
+      compatible = "wirenboard,wbec-rtc";
+      reg = <0>;
+
+      wakeup-source;
+    };
+...

--- a/Documentation/devicetree/bindings/vendor-prefixes.yaml
+++ b/Documentation/devicetree/bindings/vendor-prefixes.yaml
@@ -1574,6 +1574,8 @@ patternProperties:
     description: Winstar Display Corp.
   "^wirelesstag,.*":
     description: Wireless Tag (qiming yunduan)
+  "^wirenboard,.*":
+    description: Wiren Board, LLC
   "^wits,.*":
     description: Shenzhen Merrii Technology Co., Ltd. (WITS)
   "^wlf,.*":

--- a/Documentation/devicetree/bindings/watchdog/wirenboard,wbec-watchdog.yaml
+++ b/Documentation/devicetree/bindings/watchdog/wirenboard,wbec-watchdog.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/bindings/watchdog/wirenboard,wbec-watchdog.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Wiren Board Embedded Controller Watchdog Driver
+
+maintainers:
+  - Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+description: |
+  Enables Watchdog support on the Wiren Board Embedded Controller.
+
+properties:
+  compatible:
+    const: wirenboard,wbec-watchdog
+
+  reg:
+    const: 0
+
+required:
+  - compatible
+  - reg
+
+additionalProperties: false
+
+examples:
+  - |
+    wbec-watchdog@0 {
+      compatible = "wirenboard,wbec-watchdog";
+      reg = <0>;
+    };
+...

--- a/Documentation/driver-api/wbec.rst
+++ b/Documentation/driver-api/wbec.rst
@@ -1,0 +1,32 @@
+==============================================
+Kernel driver wbec
+==============================================
+
+Supported board/chip:
+
+  * Wiren Board Embedded Cotroller
+
+Author:
+        Pavel Gasheev <pavel.gasheev@wirenboard.com>
+
+Description
+-----------
+Wiren Board Embedded Cotroller (WBEC) is a microcontroller with special
+firmware. It is connected to the main CPU via SPI bus.
+
+The wbec is a MFD (Multi-Function Device) driver. It provides a set of
+sub-drivers for each device connected to WBEC:
+
+  * gpio-wbec - GPIO driver
+  * adc-wbec - ADC driver
+  * wdt-wbec - Watchdog driver
+  * rtc-wbec - RTC driver
+  * pwrkey-wbec - Power key driver
+  * wbec-power - Power driver
+
+The wbec driver also provides a set of sysfs attributes for WBEC:
+
+  * fwver - firmware version in text format
+  * hwver - board hardware version - a number from 0 to 4095
+  * poweron_reason - code of reason of last power on
+  * poweron_reason_str - string representation of poweron_reason

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -1547,6 +1547,20 @@ config GPIO_TWL6040
 	  Say yes here to access the GPO signals of twl6040
 	  audio chip from Texas Instruments.
 
+config GPIO_WBEC
+	tristate "Wiren Board Embedded Controller GPIO Driver"
+	depends on MFD_WBEC
+	select GPIO_REGMAP
+	select GPIOLIB_IRQCHIP
+	select REGMAP_IRQ
+	help
+	  This option enables support for GPIO connected to
+	  Wiren Board Embedded Controller.
+
+	  The driver provides only set and get function for GPIO.
+	  The direction of each GPIO is defined in Embedded Controller firmware.
+	  Number of GPIOs and it names must be defined in DT.
+
 config GPIO_WHISKEY_COVE
 	tristate "GPIO support for Whiskey Cove PMIC"
 	depends on (X86 || COMPILE_TEST) && INTEL_SOC_PMIC_BXTWC

--- a/drivers/gpio/Makefile
+++ b/drivers/gpio/Makefile
@@ -183,6 +183,7 @@ obj-$(CONFIG_GPIO_VISCONTI)		+= gpio-visconti.o
 obj-$(CONFIG_GPIO_VX855)		+= gpio-vx855.o
 obj-$(CONFIG_GPIO_WCD934X)		+= gpio-wcd934x.o
 obj-$(CONFIG_GPIO_WHISKEY_COVE)		+= gpio-wcove.o
+obj-$(CONFIG_GPIO_WBEC)			+= gpio-wbec.o
 obj-$(CONFIG_GPIO_WINBOND)		+= gpio-winbond.o
 obj-$(CONFIG_GPIO_WM831X)		+= gpio-wm831x.o
 obj-$(CONFIG_GPIO_WM8350)		+= gpio-wm8350.o

--- a/drivers/gpio/gpio-wbec.c
+++ b/drivers/gpio/gpio-wbec.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * gpio-wbec.c - Wiren Board Embedded Controller GPIO driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/gpio/driver.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/pm.h>
+#include <linux/property.h>
+#include <linux/slab.h>
+#include <linux/regmap.h>
+#include <linux/gpio/regmap.h>
+#include <linux/mfd/wbec.h>
+
+#define WBEC_GPIO_PER_REG		16
+
+static int wbec_gpio_probe(struct platform_device *pdev)
+{
+	struct gpio_regmap_config config = {};
+	struct wbec *wbec;
+	struct device *dev = &pdev->dev;
+	int ret, ngpios;
+
+	if (!pdev->dev.parent)
+		return -ENODEV;
+
+	wbec = dev_get_drvdata(pdev->dev.parent);
+
+	ret = device_property_read_u32(dev, "ngpios", &ngpios);
+	if (ret) {
+		dev_err(dev, "No ngpios property in device tree");
+		return -EINVAL;
+	}
+
+	config.ngpio = ngpios;
+	config.regmap = wbec->regmap;
+	config.parent = dev;
+	config.reg_set_base = WBEC_REG_GPIO;
+	config.ngpio_per_reg = WBEC_GPIO_PER_REG;
+	config.reg_stride = 1;
+
+	return PTR_ERR_OR_ZERO(devm_gpio_regmap_register(&pdev->dev, &config));
+}
+
+static const struct of_device_id wbec_gpio_of_match[] = {
+	{ .compatible = "wirenboard,wbec-gpio" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_gpio_of_match);
+
+static struct platform_driver wbec_gpio_driver = {
+	.driver = {
+		.name = "wbec-gpio",
+		.of_match_table = wbec_gpio_of_match,
+	},
+	.probe = wbec_gpio_probe,
+};
+module_platform_driver(wbec_gpio_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller GPIO driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:wbec-gpio");

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -1459,6 +1459,13 @@ config VIPERBOARD_ADC
 	  To compile this driver as a module, choose M here: the module will be
 	  called viperboard_adc.
 
+config WBEC_ADC
+	tristate "Wiren Board Embedded Controller ADC Driver"
+	depends on MFD_WBEC
+	help
+	  This option enables support for ADC and temperature measurement by
+	  Wiren Board Embedded Controller.
+
 config XILINX_XADC
 	tristate "Xilinx XADC driver"
 	depends on HAS_IOMEM

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -130,6 +130,7 @@ obj-$(CONFIG_TWL4030_MADC) += twl4030-madc.o
 obj-$(CONFIG_TWL6030_GPADC) += twl6030-gpadc.o
 obj-$(CONFIG_VF610_ADC) += vf610_adc.o
 obj-$(CONFIG_VIPERBOARD_ADC) += viperboard_adc.o
+obj-$(CONFIG_WBEC_ADC) += adc-wbec.o
 xilinx-xadc-y := xilinx-xadc-core.o xilinx-xadc-events.o
 obj-$(CONFIG_XILINX_XADC) += xilinx-xadc.o
 obj-$(CONFIG_XILINX_AMS) += xilinx-ams.o

--- a/drivers/iio/adc/adc-wbec.c
+++ b/drivers/iio/adc/adc-wbec.c
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * wbec_adc.c - Wiren Board Embedded Controller IIO driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/module.h>
+#include <linux/pm.h>
+#include <linux/bitops.h>
+#include <linux/regmap.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+
+#include <linux/iio/iio.h>
+#include <linux/iio/types.h>
+#include <linux/iio/sysfs.h>
+#include <linux/mfd/wbec.h>
+
+enum wbec_adc_channel {
+	WBEC_ADC_CH_V_IN,
+	WBEC_ADC_CH_V_3_3,
+	WBEC_ADC_CH_V_5_0,
+	WBEC_ADC_CH_VBUS_CONSOLE,
+	WBEC_ADC_CH_VBUS_NETWORK,
+	WBEC_ADC_CH_TEMP,
+	WBEC_ADC_CH_ADC1,
+	WBEC_ADC_CH_ADC2,
+	WBEC_ADC_CH_ADC3,
+	WBEC_ADC_CH_ADC4,
+	WBEC_ADC_CH_ADC5,
+	WBEC_ADC_CH_ADC6,
+};
+
+
+struct wbec_adc {
+	struct regmap *regmap;
+};
+
+static int read_voltage(struct regmap *map, unsigned int reg, int *voltage)
+{
+	int ret, val;
+
+	ret = regmap_read(map, reg, &val);
+	if (ret)
+		return ret;
+
+	/* Voltage in mV, u16 type */
+	*voltage = (u16)val;
+	return 0;
+}
+
+static int read_temperature(struct regmap *map, unsigned int reg, int *temperature)
+{
+	int ret, val;
+
+	ret = regmap_read(map, reg, &val);
+	if (ret)
+		return ret;
+
+	/* Temperature in deg C x100, s16 type */
+	*temperature = (s16)val;
+	return 0;
+}
+
+static int read_raw_value(struct regmap *map, struct iio_chan_spec const *channel, int *val)
+{
+	int ret;
+
+	switch (channel->type) {
+	case IIO_VOLTAGE:
+		ret = read_voltage(map, channel->address, val);
+		if (ret)
+			return ret;
+		return IIO_VAL_INT;
+
+	case IIO_TEMP:
+		ret = read_temperature(map, channel->address, val);
+		if (ret)
+			return ret;
+		return IIO_VAL_INT;
+
+	default:
+		break;
+	}
+	return -EINVAL;
+}
+
+static int read_scale(struct iio_chan_spec const *channel, int *val, int *val2)
+{
+	switch (channel->type) {
+	case IIO_VOLTAGE:
+		/* WBEC units is mV, Linux units is mV */
+		*val = 1;
+		*val2 = 0;
+		return IIO_VAL_INT;
+
+	case IIO_TEMP:
+		/* WBEC units is deg C x100, Linux units is deg C x1000 */
+		*val = 10;
+		*val2 = 0;
+		return IIO_VAL_INT;
+
+	default:
+		break;
+	}
+	return -EINVAL;
+}
+
+static int wbec_read_raw(struct iio_dev *indio_dev,
+				struct iio_chan_spec const *channel, int *val,
+				int *val2, long mask)
+{
+	struct wbec_adc *wbec_adc = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		return read_raw_value(wbec_adc->regmap, channel, val);
+
+	case IIO_CHAN_INFO_SCALE:
+		return read_scale(channel, val, val2);
+
+	default:
+		break;
+	}
+
+	return -EINVAL;
+}
+
+
+#define WBEC_ADC_CHANNEL(_id, _type, _ext_name) { \
+	.type = _type, \
+	.indexed = 1, \
+	.channel = WBEC_ADC_CH_##_id, \
+	.address = WBEC_REG_ADC_DATA_##_id, \
+	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) | BIT(IIO_CHAN_INFO_SCALE), \
+	.extend_name = _ext_name, \
+	.datasheet_name = #_id, \
+}
+
+
+static const struct iio_chan_spec wbec_adc_channels[] = {
+	WBEC_ADC_CHANNEL(V_IN, IIO_VOLTAGE, "IN"),
+	WBEC_ADC_CHANNEL(V_3_3, IIO_VOLTAGE, "3V3"),
+	WBEC_ADC_CHANNEL(V_5_0, IIO_VOLTAGE, "5V"),
+	WBEC_ADC_CHANNEL(VBUS_CONSOLE, IIO_VOLTAGE, "VBUS_CONSOLE"),
+	WBEC_ADC_CHANNEL(VBUS_NETWORK, IIO_VOLTAGE, "VBUS_NETWORK"),
+	WBEC_ADC_CHANNEL(TEMP, IIO_TEMP, "BOARD"),
+	WBEC_ADC_CHANNEL(ADC1, IIO_VOLTAGE, "ADC1"),
+	WBEC_ADC_CHANNEL(ADC2, IIO_VOLTAGE, "ADC2"),
+	WBEC_ADC_CHANNEL(ADC3, IIO_VOLTAGE, "ADC3"),
+	WBEC_ADC_CHANNEL(ADC4, IIO_VOLTAGE, "ADC4"),
+	WBEC_ADC_CHANNEL(ADC5, IIO_VOLTAGE, "ADC5"),
+	WBEC_ADC_CHANNEL(ADC6, IIO_VOLTAGE, "ADC6"),
+};
+
+static const struct iio_info wbec_adc_info = {
+	.read_raw = wbec_read_raw,
+};
+
+static int wbec_adc_probe(struct platform_device *pdev)
+{
+	struct wbec *wbec = dev_get_drvdata(pdev->dev.parent);
+	struct iio_dev *indio_dev;
+	struct wbec_adc *wbec_adc;
+
+	if (!pdev->dev.parent)
+		return -ENODEV;
+
+	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*wbec_adc));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	wbec_adc = iio_priv(indio_dev);
+
+	platform_set_drvdata(pdev, indio_dev);
+	wbec_adc->regmap = wbec->regmap;
+
+	indio_dev->name = "wbec";
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->info = &wbec_adc_info;
+
+	indio_dev->channels = wbec_adc_channels;
+	indio_dev->num_channels = ARRAY_SIZE(wbec_adc_channels);
+
+	return devm_iio_device_register(&pdev->dev, indio_dev);
+}
+
+static const struct of_device_id wbec_adc_of_match[] = {
+	{ .compatible = "wirenboard,wbec-adc" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_adc_of_match);
+
+static struct platform_driver wbec_adc_driver = {
+	.driver = {
+		.name	= "wbec-adc",
+		.of_match_table = wbec_adc_of_match,
+	},
+	.probe = wbec_adc_probe,
+};
+
+module_platform_driver(wbec_adc_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller IIO driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:wbec-adc");

--- a/drivers/input/misc/Kconfig
+++ b/drivers/input/misc/Kconfig
@@ -939,4 +939,13 @@ config INPUT_STPMIC1_ONKEY
 	  To compile this driver as a module, choose M here: the
 	  module will be called stpmic1_onkey.
 
+config INPUT_WBEC_PWRBUTTON
+	tristate "Wiren Board Embedded Controller Power Button Driver"
+	depends on MFD_WBEC
+	help
+	  This option enables support for power button connected to
+	  Wiren Board Embedded Controller.
+	  Power button can be used to power on from shutdown,
+	  safely power off and force a shutdown on long press.
+
 endif

--- a/drivers/input/misc/Makefile
+++ b/drivers/input/misc/Makefile
@@ -85,6 +85,7 @@ obj-$(CONFIG_INPUT_TWL4030_PWRBUTTON)	+= twl4030-pwrbutton.o
 obj-$(CONFIG_INPUT_TWL4030_VIBRA)	+= twl4030-vibra.o
 obj-$(CONFIG_INPUT_TWL6040_VIBRA)	+= twl6040-vibra.o
 obj-$(CONFIG_INPUT_UINPUT)		+= uinput.o
+obj-$(CONFIG_INPUT_WBEC_PWRBUTTON)	+= pwrkey-wbec.o
 obj-$(CONFIG_INPUT_WISTRON_BTNS)	+= wistron_btns.o
 obj-$(CONFIG_INPUT_WM831X_ON)		+= wm831x-on.o
 obj-$(CONFIG_INPUT_XEN_KBDDEV_FRONTEND)	+= xen-kbdfront.o

--- a/drivers/input/misc/pwrkey-wbec.c
+++ b/drivers/input/misc/pwrkey-wbec.c
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * pwrkey-wbec.c - Wiren Board Embedded Controller power key driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/errno.h>
+#include <linux/init.h>
+#include <linux/input.h>
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/regmap.h>
+#include <linux/hrtimer.h>
+#include <linux/i2c.h>
+#include <linux/workqueue.h>
+#include <linux/mfd/wbec.h>
+
+#define WBEC_PWRKEY_POLL_PERIOD_MS		500
+
+struct wbec_pwrkey {
+	struct input_dev *pwr;
+	struct delayed_work wq;
+	struct regmap *regmap;
+};
+
+void pwrkey_poll_wq(struct work_struct *work)
+{
+	struct wbec_pwrkey *wbec_pwrkey =
+		container_of(work, struct wbec_pwrkey, wq.work);
+	struct input_dev *pwr = wbec_pwrkey->pwr;
+	int val, wbec_id;
+
+	// Check that WBEC presented before read flag
+	val = regmap_read(wbec_pwrkey->regmap, WBEC_REG_INFO_WBEC_ID, &wbec_id);
+	if (val < 0) {
+		dev_err(&pwr->dev, "failed to read the wbec id at 0x%X\n",
+			WBEC_REG_INFO_WBEC_ID);
+	} else if (wbec_id != WBEC_ID) {
+		dev_err_once(&pwr->dev, "wrong wbec ID at 0x%X. Get 0x%X istead of 0x%X\n",
+			WBEC_REG_INFO_WBEC_ID, wbec_id, WBEC_ID);
+	} else {
+		val = regmap_test_bits(wbec_pwrkey->regmap, WBEC_REG_IRQ_FLAGS,
+			WBEC_REG_IRQ_PWROFF_REQ_MSK);
+
+		if (val > 0) {
+			dev_info_once(&pwr->dev, "power key press detected\n");
+			regmap_write(wbec_pwrkey->regmap, WBEC_REG_IRQ_CLEAR,
+				WBEC_REG_IRQ_PWROFF_REQ_MSK);
+			input_report_key(pwr, KEY_POWER, 1);
+			input_sync(pwr);
+			input_report_key(pwr, KEY_POWER, 0);
+			input_sync(pwr);
+		} else if (val < 0) {
+			dev_err(&pwr->dev, "Error reading power off request from EC");
+		}
+	}
+
+	schedule_delayed_work(&wbec_pwrkey->wq, msecs_to_jiffies(WBEC_PWRKEY_POLL_PERIOD_MS));
+}
+
+static int wbec_pwrkey_probe(struct platform_device *pdev)
+{
+	struct wbec *wbec = dev_get_drvdata(pdev->dev.parent);
+	struct wbec_pwrkey *wbec_pwrkey;
+	int err;
+
+	if (!pdev->dev.parent)
+		return -ENODEV;
+
+	wbec_pwrkey = devm_kzalloc(&pdev->dev, sizeof(struct wbec_pwrkey),
+				GFP_KERNEL);
+	if (!wbec_pwrkey)
+		return -ENOMEM;
+
+	wbec_pwrkey->regmap = wbec->regmap;
+
+	wbec_pwrkey->pwr = devm_input_allocate_device(&pdev->dev);
+	if (!wbec_pwrkey->pwr) {
+		dev_err(&pdev->dev, "Can't allocate power button\n");
+		return -ENOMEM;
+	}
+
+	wbec_pwrkey->pwr->name = "wbec pwrkey";
+	wbec_pwrkey->pwr->phys = "wbec_pwrkey/input0";
+	wbec_pwrkey->pwr->id.bustype = BUS_HOST;
+	input_set_capability(wbec_pwrkey->pwr, EV_KEY, KEY_POWER);
+
+	err = input_register_device(wbec_pwrkey->pwr);
+	if (err) {
+		dev_err(&pdev->dev, "Can't register power button: %d\n", err);
+		return err;
+	}
+
+	platform_set_drvdata(pdev, wbec_pwrkey);
+	device_init_wakeup(&pdev->dev, true);
+
+	INIT_DELAYED_WORK(&wbec_pwrkey->wq, pwrkey_poll_wq);
+	schedule_delayed_work(&wbec_pwrkey->wq, msecs_to_jiffies(WBEC_PWRKEY_POLL_PERIOD_MS));
+
+	return 0;
+}
+
+static int wbec_pwrkey_remove(struct platform_device *pdev)
+{
+	struct wbec_pwrkey *wbec_pwrkey = platform_get_drvdata(pdev);
+
+	dev_info(&pdev->dev, "%s function\n", __func__);
+
+	cancel_delayed_work_sync(&wbec_pwrkey->wq);
+	input_unregister_device(wbec_pwrkey->pwr);
+
+	return 0;
+}
+
+static const struct of_device_id wbec_pwrkey_of_match[] = {
+	{ .compatible = "wirenboard,wbec-pwrkey" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_pwrkey_of_match);
+
+static struct platform_driver wbec_pwrkey_driver = {
+	.driver	= {
+		.name = "wbec-pwrkey",
+		.of_match_table = wbec_pwrkey_of_match,
+	},
+	.probe	= wbec_pwrkey_probe,
+	.remove = wbec_pwrkey_remove,
+};
+module_platform_driver(wbec_pwrkey_driver);
+
+MODULE_ALIAS("platform:wbec-pwrkey");
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller Power Key driver");
+MODULE_LICENSE("GPL");

--- a/drivers/input/misc/pwrkey-wbec.c
+++ b/drivers/input/misc/pwrkey-wbec.c
@@ -28,7 +28,7 @@ struct wbec_pwrkey {
 	struct regmap *regmap;
 };
 
-void pwrkey_poll_wq(struct work_struct *work)
+static void pwrkey_poll_wq(struct work_struct *work)
 {
 	struct wbec_pwrkey *wbec_pwrkey =
 		container_of(work, struct wbec_pwrkey, wq.work);

--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -1929,6 +1929,16 @@ config MFD_CS47L24
 	help
 	  Support for Cirrus Logic CS47L24 and WM1831 low power audio SoC
 
+config MFD_WBEC
+	tristate "Wiren Board Embedded Controller MFD Driver"
+	depends on SPI && OF
+	select MFD_CORE
+	select REGMAP_SPI
+	help
+	  This driver provides common support for accessing the Wiren Board
+	  Embedded Controller through SPI interface. The device supports
+	  multiple sub-devices including RTC, WDT, pwrkey, GPIO, IIO.
+
 config MFD_WM5102
 	bool "Wolfson Microelectronics WM5102"
 	depends on MFD_ARIZONA

--- a/drivers/mfd/Makefile
+++ b/drivers/mfd/Makefile
@@ -284,3 +284,5 @@ rsmu-i2c-objs			:= rsmu_core.o rsmu_i2c.o
 rsmu-spi-objs			:= rsmu_core.o rsmu_spi.o
 obj-$(CONFIG_MFD_RSMU_I2C)	+= rsmu-i2c.o
 obj-$(CONFIG_MFD_RSMU_SPI)	+= rsmu-spi.o
+
+obj-$(CONFIG_MFD_WBEC)   += wbec.o

--- a/drivers/mfd/wbec.c
+++ b/drivers/mfd/wbec.c
@@ -412,6 +412,6 @@ static struct spi_driver wbec_driver = {
 module_spi_driver(wbec_driver);
 
 MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
-MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller MFD driver");
+MODULE_DESCRIPTION("Wiren Board Embedded Controller MFD driver");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("spi:wbec");

--- a/drivers/mfd/wbec.c
+++ b/drivers/mfd/wbec.c
@@ -259,15 +259,10 @@ static inline void wbec_clean_debugfs(struct wbec *wbec)
 }
 #endif
 
-static struct wbec *wbec_pm;
-
-static void wbec_pm_power_off(void)
+static int wbec_power_off(struct sys_off_data *data)
 {
 	int ret;
-	struct wbec *wbec = wbec_pm;
-
-	if (!wbec)
-		return;
+	struct wbec *wbec = data->cb_data;
 
 	ret = regmap_write(wbec->regmap, WBEC_REG_POWER_CTRL, WBEC_REG_POWER_CTRL_OFF_MSK);
 	if (ret)
@@ -276,15 +271,14 @@ static void wbec_pm_power_off(void)
 	/* Give capacitors etc. time to drain to avoid kernel panic msg. */
 	msleep(WBEC_POWER_RESET_DELAY_MS);
 	dev_err(wbec->dev, "Device not actually shutdown. Check EC and FETs!\n");
+
+	return NOTIFY_DONE;
 }
 
-static int wbec_restart_notify(struct notifier_block *this, unsigned long mode, void *cmd)
+static int wbec_restart(struct sys_off_data *data)
 {
-	struct wbec *wbec = wbec_pm;
 	int ret;
-
-	if (!wbec)
-		return NOTIFY_STOP;
+	struct wbec *wbec = data->cb_data;
 
 	ret = regmap_write(wbec->regmap, WBEC_REG_POWER_CTRL, WBEC_REG_POWER_CTRL_REBOOT_MSK);
 	if (ret)
@@ -296,11 +290,6 @@ static int wbec_restart_notify(struct notifier_block *this, unsigned long mode, 
 
 	return NOTIFY_DONE;
 }
-
-static struct notifier_block wbec_restart_handler = {
-	.notifier_call = wbec_restart_notify,
-	.priority = 255,
-};
 
 static int wbec_probe(struct spi_device *spi)
 {
@@ -351,12 +340,15 @@ static int wbec_probe(struct spi_device *spi)
 		return ret;
 	}
 
-	wbec_pm = wbec;
-	pm_power_off = wbec_pm_power_off;
+	devm_register_sys_off_handler(wbec->dev,
+		SYS_OFF_MODE_POWER_OFF,
+		SYS_OFF_PRIO_FIRMWARE,
+		wbec_power_off, wbec);
 
-	ret = register_restart_handler(&wbec_restart_handler);
-	if (ret)
-		dev_warn(&spi->dev, "failed to register restart handler\n");
+	devm_register_sys_off_handler(wbec->dev,
+		SYS_OFF_MODE_RESTART,
+		SYS_OFF_PRIO_FIRMWARE,
+		wbec_restart, wbec);
 
 	wbec_setup_debugfs(wbec);
 
@@ -368,14 +360,6 @@ static int wbec_probe(struct spi_device *spi)
 static void wbec_remove(struct spi_device *spi)
 {
 	struct wbec *wbec = spi_get_drvdata(spi);
-	/**
-	 * pm_power_off may point to a function from another module.
-	 * Check if the pointer is set by us and only then overwrite it.
-	 */
-	if (pm_power_off == wbec_pm_power_off) {
-		pm_power_off = NULL;
-		unregister_restart_handler(&wbec_restart_handler);
-	}
 
 	sysfs_remove_group(&wbec->dev->kobj, &wbec_attr_group);
 	wbec_clean_debugfs(wbec);

--- a/drivers/mfd/wbec.c
+++ b/drivers/mfd/wbec.c
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * wbec.c - Wiren Board Embedded Controller MFD driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/spi/spi.h>
+#include <linux/rtc.h>
+#include <linux/mfd/core.h>
+#include <linux/interrupt.h>
+#include <linux/reboot.h>
+#include <linux/notifier.h>
+#include <linux/mfd/wbec.h>
+#include <linux/mod_devicetable.h>
+#include <linux/debugfs.h>
+#include <linux/seq_file.h>
+
+/* For power off WBEC activates PWON pin on PMIC for 6s */
+#define WBEC_POWER_RESET_DELAY_MS			10000
+
+static const char * const wbec_poweron_reason[] = {
+	"Power supply on",
+	"Power button",
+	"RTC alarm",
+	"Reboot",
+	"Reboot instead of poweroff",
+	"Watchdog",
+	"PMIC is unexpectedly off",
+};
+
+static const struct regmap_config wbec_regmap_config = {
+	.reg_bits = 16,
+	.read_flag_mask = BIT(7),
+	.val_bits = 16,
+	.max_register = 0xFF,
+};
+
+static const struct mfd_cell wbec_cells[] = {
+	{
+		.name = "wbec-adc",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-adc"
+	},
+	{
+		.name = "wbec-gpio",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-gpio"
+	},
+	{
+		.name = "wbec-watchdog",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-watchdog"
+	},
+	{
+		.name = "wbec-rtc",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-rtc"
+	},
+	{
+		.name = "wbec-pwrkey",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-pwrkey"
+	},
+	{
+		.name = "wbec-power",
+		.id = PLATFORM_DEVID_NONE,
+		.of_compatible = "wirenboard,wbec-power"
+	},
+};
+
+/* ----------------------------------------------------------------------- */
+/* SysFS interface */
+
+static ssize_t
+fwrev_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	union wbec_version {
+		struct {
+			u16 major;
+			u16 minor;
+			u16 patch;
+			s16 suffix;
+		};
+		u16 raw[4];
+	} version;
+	struct wbec *wbec = dev_get_drvdata(dev);
+	int ret;
+	char suffix_str[32] = "";
+
+	ret = regmap_bulk_read(wbec->regmap, WBEC_REG_INFO_FW_VER_MAJOR,
+			version.raw, sizeof(version.raw));
+	if (ret)
+		return ret;
+
+	if (version.suffix > 0)
+		sprintf(suffix_str, "+wb%d", version.suffix);
+	else if (version.suffix < 0)
+		sprintf(suffix_str, "-rc%d", -version.suffix);
+
+	return sprintf(buf, "%d.%d.%d%s\n",
+			version.major, version.minor, version.patch, suffix_str);
+}
+
+static ssize_t
+hwrev_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	struct wbec *wbec = dev_get_drvdata(dev);
+	int ret, hwrev;
+
+	ret = regmap_read(wbec->regmap, WBEC_REG_INFO_BOARD_REV, &hwrev);
+	if (ret)
+		return ret;
+
+	return sprintf(buf, "%d\n", (u16)hwrev);
+}
+
+static ssize_t
+poweron_reason_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	struct wbec *wbec = dev_get_drvdata(dev);
+	int ret, reason;
+
+	ret = regmap_read(wbec->regmap, WBEC_REG_INFO_POWERON_REASON, &reason);
+	if (ret)
+		return ret;
+
+	return sprintf(buf, "%d\n", reason);
+}
+
+static ssize_t
+poweron_reason_str_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	struct wbec *wbec = dev_get_drvdata(dev);
+	int ret, reason;
+
+	ret = regmap_read(wbec->regmap, WBEC_REG_INFO_POWERON_REASON, &reason);
+	if (ret)
+		return ret;
+
+	if (reason >= ARRAY_SIZE(wbec_poweron_reason))
+		return sprintf(buf, "Unknown\n");
+
+	return sprintf(buf, "%s\n", wbec_poweron_reason[reason]);
+}
+
+
+static DEVICE_ATTR_RO(fwrev);
+static DEVICE_ATTR_RO(hwrev);
+static DEVICE_ATTR_RO(poweron_reason);
+static DEVICE_ATTR_RO(poweron_reason_str);
+
+static struct attribute *wbec_sysfs_entries[] = {
+	&dev_attr_fwrev.attr,
+	&dev_attr_hwrev.attr,
+	&dev_attr_poweron_reason.attr,
+	&dev_attr_poweron_reason_str.attr,
+	NULL,
+};
+
+static const struct attribute_group wbec_attr_group = {
+	.attrs	= wbec_sysfs_entries,
+};
+
+
+#ifdef CONFIG_DEBUG_FS
+/*
+ * debugfs entries only exposed if we're using debug
+ */
+
+static ssize_t wbec_write_reg(struct file *file,
+				  const char __user *user_buf,
+				  size_t count, loff_t *ppos)
+{
+	struct wbec *wbec = file->private_data;
+	char buf[32];
+	ssize_t buf_size;
+	int regp;
+	u16 reg_addr, reg_value;
+	int err;
+	int i = 0;
+
+	/* Get userspace string and assure termination */
+	buf_size = min((ssize_t)count, (ssize_t)(sizeof(buf)-1));
+	if (copy_from_user(buf, user_buf, buf_size))
+		return -EFAULT;
+	buf[buf_size] = 0;
+
+	/* The string format is "wbec: 0xnn 0xnn" for writing a register. */
+
+	/* Check prefix */
+	if (strncmp(buf, "wbec: ", 6) != 0)
+		return -EINVAL;
+
+	/* Get register address: skip spaces */
+	i = 6;
+	while ((i < buf_size) && (buf[i] == ' '))
+		i++;
+	regp = i;
+	/* And replace first space after value with null-termination char */
+	while ((i < buf_size) && (buf[i] != ' '))
+		i++;
+	buf[i] = '\0';
+
+	err = kstrtou16(&buf[regp], 16, &reg_addr);
+	if (err)
+		return err;
+
+	/* Get register value: the same method */
+	i++;
+	while ((i < buf_size) && (buf[i] == ' '))
+		i++;
+	err = kstrtou16(&buf[i], 16, &reg_value);
+	if (err)
+		return err;
+
+	/* Write register */
+	dev_info(wbec->dev, "debugfs writing 0x%04X to 0x%04X\n", reg_value, reg_addr);
+	err = regmap_write(wbec->regmap, reg_addr, reg_value);
+	if (err)
+		return err;
+
+	return buf_size;
+}
+
+static const struct file_operations wbec_write_reg_fops = {
+	.open = simple_open,
+	.write = wbec_write_reg,
+	.llseek = noop_llseek,
+};
+
+static void wbec_setup_debugfs(struct wbec *wbec)
+{
+	wbec->wbec_dir = debugfs_create_dir("wbec", NULL);
+
+	debugfs_create_file("write_reg", 0200, wbec->wbec_dir, wbec,
+			    &wbec_write_reg_fops);
+}
+
+static void wbec_clean_debugfs(struct wbec *wbec)
+{
+	debugfs_remove_recursive(wbec->wbec_dir);
+}
+#else
+static inline void wbec_setup_debugfs(struct wbec *wbec)
+{
+}
+static inline void wbec_clean_debugfs(struct wbec *wbec)
+{
+}
+#endif
+
+static struct wbec *wbec_pm;
+
+static void wbec_pm_power_off(void)
+{
+	int ret;
+	struct wbec *wbec = wbec_pm;
+
+	if (!wbec)
+		return;
+
+	ret = regmap_write(wbec->regmap, WBEC_REG_POWER_CTRL, WBEC_REG_POWER_CTRL_OFF_MSK);
+	if (ret)
+		dev_err(wbec->dev, "Failed to shutdown device!\n");
+
+	/* Give capacitors etc. time to drain to avoid kernel panic msg. */
+	msleep(WBEC_POWER_RESET_DELAY_MS);
+	dev_err(wbec->dev, "Device not actually shutdown. Check EC and FETs!\n");
+}
+
+static int wbec_restart_notify(struct notifier_block *this, unsigned long mode, void *cmd)
+{
+	struct wbec *wbec = wbec_pm;
+	int ret;
+
+	if (!wbec)
+		return NOTIFY_STOP;
+
+	ret = regmap_write(wbec->regmap, WBEC_REG_POWER_CTRL, WBEC_REG_POWER_CTRL_REBOOT_MSK);
+	if (ret)
+		dev_err(wbec->dev, "Failed to reboot device!\n");
+
+	/* Give capacitors etc. time to drain to avoid kernel panic msg. */
+	msleep(WBEC_POWER_RESET_DELAY_MS);
+	dev_err(wbec->dev, "Device not actually rebooted. Check EC and FETs!\n");
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block wbec_restart_handler = {
+	.notifier_call = wbec_restart_notify,
+	.priority = 255,
+};
+
+static int wbec_probe(struct spi_device *spi)
+{
+	struct wbec *wbec;
+	int ret;
+	int wbec_id;
+
+	wbec = devm_kzalloc(&spi->dev, sizeof(*wbec), GFP_KERNEL);
+	if (!wbec)
+		return -ENOMEM;
+
+	wbec->dev = &spi->dev;
+
+	spi->mode = SPI_MODE_0;
+	spi->bits_per_word = 8;
+	spi_setup(spi);
+
+	spi_set_drvdata(spi, wbec);
+
+	wbec->regmap = devm_regmap_init_spi(spi, &wbec_regmap_config);
+	if (IS_ERR(wbec->regmap)) {
+		dev_err(&spi->dev, "regmap initialization failed\n");
+		return PTR_ERR(wbec->regmap);
+	}
+
+	ret = regmap_read(wbec->regmap, WBEC_REG_INFO_WBEC_ID, &wbec_id);
+	if (ret < 0) {
+		dev_err(&spi->dev, "failed to read the wbec id at 0x%X\n",
+			WBEC_REG_INFO_WBEC_ID);
+		return ret;
+	}
+	if (wbec_id != WBEC_ID) {
+		dev_err(&spi->dev, "wrong wbec ID at 0x%X. Get 0x%X istead of 0x%X\n",
+			WBEC_REG_INFO_WBEC_ID, wbec_id, WBEC_ID);
+		return -ENOTSUPP;
+	}
+
+	ret = sysfs_create_group(&wbec->dev->kobj, &wbec_attr_group);
+	if (ret) {
+		dev_err(&spi->dev, "failed to create sysfs group\n");
+		return ret;
+	}
+
+	ret = devm_mfd_add_devices(&spi->dev, PLATFORM_DEVID_NONE,
+			      wbec_cells, ARRAY_SIZE(wbec_cells), NULL, 0, NULL);
+	if (ret) {
+		dev_err(&spi->dev, "failed to add MFD devices %d\n", ret);
+		return ret;
+	}
+
+	wbec_pm = wbec;
+	pm_power_off = wbec_pm_power_off;
+
+	ret = register_restart_handler(&wbec_restart_handler);
+	if (ret)
+		dev_warn(&spi->dev, "failed to register restart handler\n");
+
+	wbec_setup_debugfs(wbec);
+
+	dev_info(&spi->dev, "WBEC device added\n");
+
+	return ret;
+}
+
+static void wbec_remove(struct spi_device *spi)
+{
+	struct wbec *wbec = spi_get_drvdata(spi);
+	/**
+	 * pm_power_off may point to a function from another module.
+	 * Check if the pointer is set by us and only then overwrite it.
+	 */
+	if (pm_power_off == wbec_pm_power_off) {
+		pm_power_off = NULL;
+		unregister_restart_handler(&wbec_restart_handler);
+	}
+
+	sysfs_remove_group(&wbec->dev->kobj, &wbec_attr_group);
+	wbec_clean_debugfs(wbec);
+}
+
+static const struct spi_device_id wbec_spi_id[] = {
+	{"wbec", 0},
+	{}
+};
+MODULE_DEVICE_TABLE(spi, wbec_spi_id);
+
+static const struct of_device_id wbec_of_match[] = {
+	{ .compatible = "wirenboard,wbec" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_of_match);
+
+static struct spi_driver wbec_driver = {
+	.driver = {
+		.name = "wbec",
+		.of_match_table = wbec_of_match,
+	},
+	.probe = wbec_probe,
+	.remove = wbec_remove,
+	.id_table = wbec_spi_id,
+};
+
+
+module_spi_driver(wbec_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller MFD driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("spi:wbec");

--- a/drivers/mfd/wbec.c
+++ b/drivers/mfd/wbec.c
@@ -153,17 +153,38 @@ poweron_reason_str_show(struct device *dev,
 	return sprintf(buf, "%s\n", wbec_poweron_reason[reason]);
 }
 
+static ssize_t
+uid_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct wbec *wbec = dev_get_drvdata(dev);
+	int i, ret;
+	char *buf_start = buf;
+	u8 uid[12];
+
+	ret = regmap_bulk_read(wbec->regmap, WBEC_REG_INFO_UID, uid, 6);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < ARRAY_SIZE(uid); i++)
+		buf += sprintf(buf, "%02x", uid[i]);
+
+	buf += sprintf(buf, "\n");
+
+	return buf - buf_start;
+}
 
 static DEVICE_ATTR_RO(fwrev);
 static DEVICE_ATTR_RO(hwrev);
 static DEVICE_ATTR_RO(poweron_reason);
 static DEVICE_ATTR_RO(poweron_reason_str);
+static DEVICE_ATTR_RO(uid);
 
 static struct attribute *wbec_sysfs_entries[] = {
 	&dev_attr_fwrev.attr,
 	&dev_attr_hwrev.attr,
 	&dev_attr_poweron_reason.attr,
 	&dev_attr_poweron_reason_str.attr,
+	&dev_attr_uid.attr,
 	NULL,
 };
 

--- a/drivers/power/supply/Kconfig
+++ b/drivers/power/supply/Kconfig
@@ -894,6 +894,15 @@ config CHARGER_BD99954
 	  information and altering charger configurations from the ROHM
 	  BD99954 charger IC.
 
+config WBEC_POWER
+	tristate "Wiren Board Embedded Controller Power Supply Driver"
+	depends on MFD_WBEC
+	help
+	  This option enables support for power status of
+	  Wiren Board.
+
+	  The driver provides power supply class for the Wiren Board.
+
 config CHARGER_WILCO
 	tristate "Wilco EC based charger for ChromeOS"
 	depends on WILCO_EC

--- a/drivers/power/supply/Makefile
+++ b/drivers/power/supply/Makefile
@@ -106,6 +106,7 @@ obj-$(CONFIG_CHARGER_SC2731)	+= sc2731_charger.o
 obj-$(CONFIG_FUEL_GAUGE_SC27XX)	+= sc27xx_fuel_gauge.o
 obj-$(CONFIG_CHARGER_UCS1002)	+= ucs1002_power.o
 obj-$(CONFIG_CHARGER_BD99954)	+= bd99954-charger.o
+obj-$(CONFIG_WBEC_POWER)	+= wbec-power.o
 obj-$(CONFIG_CHARGER_WILCO)	+= wilco-charger.o
 obj-$(CONFIG_RN5T618_POWER)	+= rn5t618_power.o
 obj-$(CONFIG_BATTERY_ACER_A500)	+= acer_a500_battery.o

--- a/drivers/power/supply/wbec-power.c
+++ b/drivers/power/supply/wbec-power.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * wbec-power.c - Wiren Board Embedded Controller Power Supply driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/device.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/power_supply.h>
+#include <linux/of.h>
+#include <linux/regmap.h>
+
+#include <linux/mfd/wbec.h>
+
+struct wbec_power {
+	struct regmap *regmap;
+
+	struct power_supply *charger;
+	struct power_supply_desc charger_desc;
+};
+
+static int wbec_power_get_property(struct power_supply *psy,
+		enum power_supply_property psp, union power_supply_propval *val)
+{
+	struct wbec_power *wbec_power = power_supply_get_drvdata(psy);
+	int ret;
+
+	if (psp == POWER_SUPPLY_PROP_ONLINE) {
+		ret = regmap_test_bits(wbec_power->regmap,
+			WBEC_REG_PWR_STATUS,
+			WBEC_REG_PWR_STATUS_POWERED_FROM_WBMZ_MSK);
+		if (ret < 0)
+			return ret;
+		// If bit is set, it means that WB is powered
+		// from battery and main power is off
+		val->intval = ret ? 0 : 1;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int wbec_power_set_property(struct power_supply *psy,
+	enum power_supply_property psp, const union power_supply_propval *val)
+{
+	return -EINVAL;
+}
+
+static int wbec_power_property_is_writeable(struct power_supply *psy,
+					      enum power_supply_property psp)
+{
+	return 0;
+}
+
+static const enum power_supply_property wbec_power_properties[] = {
+	POWER_SUPPLY_PROP_ONLINE,
+};
+
+static int wbec_power_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct wbec *wbec;
+	struct power_supply_config psy_cfg = {};
+	struct power_supply_desc *charger_desc;
+	struct wbec_power *wbec_power;
+	int ret;
+
+	if (!dev->parent)
+		return -ENODEV;
+
+	wbec_power = devm_kzalloc(dev, sizeof(*wbec_power), GFP_KERNEL);
+	if (!wbec_power)
+		return -ENOMEM;
+
+	wbec = dev_get_drvdata(dev->parent);
+	wbec_power->regmap = wbec->regmap;
+
+	charger_desc = &wbec_power->charger_desc;
+	charger_desc->properties = wbec_power_properties;
+	charger_desc->num_properties = ARRAY_SIZE(wbec_power_properties);
+	charger_desc->get_property = wbec_power_get_property;
+	charger_desc->set_property = wbec_power_set_property;
+	charger_desc->property_is_writeable =
+					wbec_power_property_is_writeable;
+
+	psy_cfg.of_node = dev->of_node;
+	psy_cfg.drv_data = wbec_power;
+
+	charger_desc->type = POWER_SUPPLY_TYPE_MAINS;
+
+	if (!charger_desc->name)
+		charger_desc->name = pdev->name;
+
+	wbec_power->charger = devm_power_supply_register(dev, charger_desc,
+							   &psy_cfg);
+	if (IS_ERR(wbec_power->charger)) {
+		ret = PTR_ERR(wbec_power->charger);
+		dev_err(dev, "Failed to register power supply: %d\n", ret);
+		return ret;
+	}
+
+	platform_set_drvdata(pdev, wbec_power);
+
+	return 0;
+}
+
+static const struct of_device_id wbec_power_of_match[] = {
+	{ .compatible = "wirenboard,wbec-power" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, wbec_power_of_match);
+
+static struct platform_driver wbec_power_driver = {
+	.probe = wbec_power_probe,
+	.driver = {
+		.name = "wbec-power",
+		.of_match_table = wbec_power_of_match,
+	},
+};
+
+module_platform_driver(wbec_power_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller PWR driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:wbec-power");

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -2032,4 +2032,12 @@ config RTC_DRV_SSD202D
 	  This driver can also be built as a module, if so, the module
 	  will be called "rtc-ssd20xd".
 
+config RTC_DRV_WBEC
+	tristate "Wiren Board Embedded Controller RTC Driver"
+	depends on MFD_WBEC
+	help
+	  This option enables support for Real Time Clock on the
+	  Wiren Board Embedded Controller.
+	  Also rtcwake from poweroff mode is supported.
+
 endif # RTC_CLASS

--- a/drivers/rtc/Makefile
+++ b/drivers/rtc/Makefile
@@ -182,6 +182,7 @@ obj-$(CONFIG_RTC_DRV_TPS6594)	+= rtc-tps6594.o
 obj-$(CONFIG_RTC_DRV_TPS65910)	+= rtc-tps65910.o
 obj-$(CONFIG_RTC_DRV_TWL4030)	+= rtc-twl.o
 obj-$(CONFIG_RTC_DRV_VT8500)	+= rtc-vt8500.o
+obj-$(CONFIG_RTC_DRV_WBEC)	+= rtc-wbec.o
 obj-$(CONFIG_RTC_DRV_WILCO_EC)	+= rtc-wilco-ec.o
 obj-$(CONFIG_RTC_DRV_WM831X)	+= rtc-wm831x.o
 obj-$(CONFIG_RTC_DRV_WM8350)	+= rtc-wm8350.o

--- a/drivers/rtc/rtc-wbec.c
+++ b/drivers/rtc/rtc-wbec.c
@@ -238,6 +238,7 @@ static int wbec_rtc_probe(struct platform_device *pdev)
 		return PTR_ERR(wbec_rtc->rtc);
 
 	wbec_rtc->rtc->ops = &wbec_rtc_ops;
+	clear_bit(RTC_FEATURE_UPDATE_INTERRUPT, wbec_rtc->rtc->features);
 
 	device_init_wakeup(&pdev->dev, true);
 

--- a/drivers/rtc/rtc-wbec.c
+++ b/drivers/rtc/rtc-wbec.c
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * rtc-wbec.c - Wiren Board Embedded Controller RTC driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/rtc.h>
+#include <linux/platform_device.h>
+#include <linux/time.h>
+#include <linux/regmap.h>
+#include <linux/of_device.h>
+#include <linux/mfd/wbec.h>
+
+#define WBEC_RTC_OFFSET_LSB_PPB_X10	9537	/* 0.9537 ppm */
+#define WBEC_RTC_CALM_TO_PPB(x)		((x) * WBEC_RTC_OFFSET_LSB_PPB_X10 / 10)
+#define WBEC_RTC_PPB_TO_CALM(x)		((x) * 10 / WBEC_RTC_OFFSET_LSB_PPB_X10)
+#define WBEC_RTC_MAX_PLUS_OFFSET	512
+#define WBEC_RTC_MAX_MINUS_OFFSET	-511
+
+struct wbec_rtc_config {
+	struct regmap_config regmap;
+};
+
+struct wbec_rtc {
+	struct rtc_device	*rtc;
+	struct regmap		*regmap;
+};
+
+static int wbec_rtc_read_time(struct device *dev, struct rtc_time *tm)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+
+	int rc;
+	u16 regs[4];
+
+	/*
+	 * while reading, the time/date registers are blocked and not updated
+	 * anymore until the access is finished. To not lose a second
+	 * event, the access must be finished within one second. So, read all
+	 * time/date registers in one turn.
+	 */
+	rc = regmap_bulk_read(wbec_rtc->regmap, WBEC_REG_RTC_TIME_SECS_MINS, regs,
+				  ARRAY_SIZE(regs));
+	if (rc)
+		return rc;
+
+	tm->tm_sec = regs[0] & 0x00FF;
+	tm->tm_min = regs[0] >> 8;
+	tm->tm_hour = regs[1] & 0x00FF;
+	tm->tm_mday = regs[1] >> 8;
+	tm->tm_wday = regs[2] & 0x00FF;
+	tm->tm_mon = (regs[2] >> 8) - 1;
+	tm->tm_year = regs[3];
+	tm->tm_year += 100;
+
+	return 0;
+}
+
+static int wbec_rtc_set_time(struct device *dev, struct rtc_time *tm)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+	int rc;
+	u16 regs[4];
+
+	/* hours, minutes and seconds */
+	regs[0] = tm->tm_sec;
+	regs[0] |= tm->tm_min << 8;
+	regs[1] = tm->tm_hour;
+
+	/* Day of month, 1 - 31 */
+	regs[1] |= tm->tm_mday << 8;
+
+	/* Day, 0 - 6 */
+	regs[2] = tm->tm_wday & 0x07;
+
+	/* month, 1 - 12 */
+	regs[2] |= (tm->tm_mon + 1) << 8;
+
+	/* year and century */
+	regs[3] = tm->tm_year - 100;
+
+	/* write all registers at once */
+	rc = regmap_bulk_write(wbec_rtc->regmap, WBEC_REG_RTC_TIME_SECS_MINS,
+				   regs, ARRAY_SIZE(regs));
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
+static int wbec_rtc_read_alarm(struct device *dev, struct rtc_wkalrm *alrm)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+	u16 buf[4];
+	int ret;
+
+	ret = regmap_bulk_read(wbec_rtc->regmap, WBEC_REG_RTC_ALARM_SECS_MINS,
+				   buf, ARRAY_SIZE(buf));
+	if (ret)
+		return ret;
+
+	alrm->time.tm_sec = buf[0] & 0x00FF;
+	alrm->time.tm_min = buf[0] >> 8;
+	alrm->time.tm_hour = buf[1] & 0x00FF;
+	alrm->time.tm_mday = buf[1] >> 8;
+
+	alrm->enabled =  !!(buf[2] & WBEC_REG_RTC_ALARM_STATUS_EN_MSK);
+
+	return 0;
+}
+
+static int wbec_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *alrm)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+	u16 buf[4] = {};
+
+	buf[0] = alrm->time.tm_sec;
+	buf[0] |= alrm->time.tm_min << 8;
+	buf[1] = alrm->time.tm_hour;
+	buf[1] |= alrm->time.tm_mday << 8;
+
+	if (alrm->enabled)
+		buf[2] |= WBEC_REG_RTC_ALARM_STATUS_EN_MSK;
+
+	return regmap_bulk_write(wbec_rtc->regmap, WBEC_REG_RTC_ALARM_SECS_MINS,
+				buf, ARRAY_SIZE(buf));
+}
+
+static int wbec_rtc_alarm_irq_enable(struct device *dev,
+					 unsigned int enabled)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+
+	return regmap_update_bits(wbec_rtc->regmap, WBEC_REG_RTC_ALARM_STATUS,
+				  WBEC_REG_RTC_ALARM_STATUS_EN_MSK,
+				  enabled ? WBEC_REG_RTC_ALARM_STATUS_EN_MSK : 0);
+}
+
+static int wbec_rtc_read_offset(struct device *dev, long *offset)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+	int ret;
+	long tmp = 0;
+	int reg;
+
+	ret = regmap_read(wbec_rtc->regmap, WBEC_REG_RTC_CFG_OFFSET, &reg);
+	if (ret)
+		return ret;
+
+	/* Linux units is ppb
+	 * wbec offset register represents STM32G0 RTC_CALR register:
+	 * Bit 15 CALP: Increase frequency of RTC by 488.5ppm
+	 * Bit 14 CALW8: Use an 8-second calibration cycle period
+	 * Bit 13 CALW16: Use a 16-second calibration cycle period
+	 * Bits 8:0 CALM[8:0]: Calibration minus
+	 * 1 lsb in wbec is 0.9537 ppm
+	 *
+	 * Formula is (512 × CALP) - CALM
+	 * CALW8 and CALW16 unused
+	 */
+
+	if (reg & WBEC_REG_RTC_CFG_OFFSET_CALP_BIT)
+		tmp = WBEC_RTC_MAX_PLUS_OFFSET;
+	tmp -= reg & WBEC_REG_RTC_CFG_OFFSET_CALM_MASK;
+
+	*offset = WBEC_RTC_CALM_TO_PPB(tmp);
+
+	return 0;
+}
+
+static int wbec_rtc_set_offset(struct device *dev, long offset)
+{
+	struct wbec_rtc *wbec_rtc = dev_get_drvdata(dev);
+	u16 reg = 0;
+	long tmp = 0;
+
+	/* Convert offset to EC units */
+	tmp = WBEC_RTC_PPB_TO_CALM(offset);
+
+	/* Limit min and max offset */
+	if (tmp > WBEC_RTC_MAX_PLUS_OFFSET)
+		tmp = WBEC_RTC_MAX_PLUS_OFFSET;
+	if (tmp < WBEC_RTC_MAX_MINUS_OFFSET)
+		tmp = WBEC_RTC_MAX_MINUS_OFFSET;
+
+	if (tmp > 0)
+		reg = WBEC_REG_RTC_CFG_OFFSET_CALP_BIT | (WBEC_RTC_MAX_PLUS_OFFSET - tmp);
+	else
+		reg = -tmp;
+
+	return regmap_write(wbec_rtc->regmap, WBEC_REG_RTC_CFG_OFFSET, reg);
+}
+
+static const struct rtc_class_ops wbec_rtc_ops = {
+	.read_time	= wbec_rtc_read_time,
+	.set_time	= wbec_rtc_set_time,
+	.read_offset = wbec_rtc_read_offset,
+	.set_offset	= wbec_rtc_set_offset,
+	.read_alarm = wbec_rtc_read_alarm,
+	.set_alarm = wbec_rtc_set_alarm,
+	.alarm_irq_enable = wbec_rtc_alarm_irq_enable,
+};
+
+static int wbec_rtc_probe(struct platform_device *pdev)
+{
+	struct wbec *wbec = dev_get_drvdata(pdev->dev.parent);
+	struct wbec_rtc *wbec_rtc;
+
+	unsigned int tmp;
+	int err;
+
+	if (!pdev->dev.parent)
+		return -ENODEV;
+
+	wbec_rtc = devm_kzalloc(&pdev->dev, sizeof(struct wbec_rtc),
+				GFP_KERNEL);
+	if (!wbec_rtc)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, wbec_rtc);
+	wbec_rtc->regmap = wbec->regmap;
+
+	err = regmap_read(wbec_rtc->regmap, WBEC_REG_RTC_TIME_SECS_MINS, &tmp);
+	if (err) {
+		dev_err(&pdev->dev, "RTC chip is not present\n");
+		return err;
+	}
+
+	wbec_rtc->rtc = devm_rtc_allocate_device(&pdev->dev);
+	if (IS_ERR(wbec_rtc->rtc))
+		return PTR_ERR(wbec_rtc->rtc);
+
+	wbec_rtc->rtc->ops = &wbec_rtc_ops;
+
+	device_init_wakeup(&pdev->dev, true);
+
+	return devm_rtc_register_device(wbec_rtc->rtc);
+}
+
+static const struct of_device_id wbec_rtc_of_match[] = {
+	{ .compatible = "wirenboard,wbec-rtc" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_rtc_of_match);
+
+static struct platform_driver wbec_rtc_driver = {
+	.driver		= {
+		.name	= "wbec-rtc",
+		.of_match_table = wbec_rtc_of_match,
+	},
+	.probe	= wbec_rtc_probe,
+};
+
+module_platform_driver(wbec_rtc_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller RTC driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:wbec-rtc");

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -368,6 +368,14 @@ config SL28CPLD_WATCHDOG
 	  To compile this driver as a module, choose M here: the
 	  module will be called sl28cpld_wdt.
 
+config WBEC_WATCHDOG
+	tristate "Wiren Board Embedded Controller Watchdog Driver"
+	depends on MFD_WBEC
+	select WATCHDOG_CORE
+	help
+	  This option enables support for the watchdog timer
+	  on the Wiren Board Embedded Controller.
+
 # ALPHA Architecture
 
 # ARM Architecture

--- a/drivers/watchdog/Makefile
+++ b/drivers/watchdog/Makefile
@@ -234,3 +234,4 @@ obj-$(CONFIG_MENZ069_WATCHDOG) += menz69_wdt.o
 obj-$(CONFIG_RAVE_SP_WATCHDOG) += rave-sp-wdt.o
 obj-$(CONFIG_STPMIC1_WATCHDOG) += stpmic1_wdt.o
 obj-$(CONFIG_SL28CPLD_WATCHDOG) += sl28cpld_wdt.o
+obj-$(CONFIG_WBEC_WATCHDOG) += wdt-wbec.o

--- a/drivers/watchdog/wdt-wbec.c
+++ b/drivers/watchdog/wdt-wbec.c
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * wdt-wbec.c - Wiren Board Embedded Controller watchdog driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/watchdog.h>
+#include <linux/platform_device.h>
+#include <linux/uaccess.h>
+#include <linux/slab.h>
+#include <linux/i2c.h>
+#include <linux/delay.h>
+#include <linux/jiffies.h>
+#include <linux/property.h>
+#include <linux/regmap.h>
+#include <linux/of.h>
+#include <linux/mfd/wbec.h>
+
+
+#define WBEC_WDT_MIN_TIMEOUT		1
+#define WBEC_WDT_MAX_TIMEOUT		600
+#define WBEC_WDG_DEFAULT_TIMEOUT	60
+#define WBEC_WDG_STOP_TIMEOUT		300
+#define WBEC_RESET_PROTECTION_MS	300
+
+struct wbec_watchdog {
+	struct device *dev;
+	struct regmap *regmap;
+	struct watchdog_device wdtdev;
+};
+
+static int wbec_wdt_start(struct watchdog_device *wdd)
+{
+	// Nothing to do here, watchdog always running
+	return 0;
+}
+
+static int wbec_wdt_ping(struct watchdog_device *wdd)
+{
+	struct wbec_watchdog *wdt = watchdog_get_drvdata(wdd);
+	int ret;
+
+	ret = regmap_update_bits(wdt->regmap,
+				 WBEC_REG_WDT_STATUS,
+				 WBEC_REG_WDT_STATUS_RESET_MSK,
+				 WBEC_REG_WDT_STATUS_RESET_MSK);
+	if (ret)
+		dev_err(wdt->dev, "Failed to ping the watchdog (err = %d)\n",
+			ret);
+
+	return ret;
+}
+
+static int wbec_wdt_set_timeout(struct watchdog_device *wdd,
+				  unsigned int timeout)
+{
+	struct wbec_watchdog *wdt = watchdog_get_drvdata(wdd);
+	int ret;
+
+	if (timeout > WBEC_WDT_MAX_TIMEOUT) {
+		timeout = WBEC_WDT_MAX_TIMEOUT;
+		wdd->timeout = WBEC_WDT_MAX_TIMEOUT;
+	}
+
+	ret = regmap_write(wdt->regmap, WBEC_REG_WDT_TIMEOUT, timeout);
+	if (ret)
+		dev_err(wdt->dev, "Failed to set watchdog timeout (err = %d)\n",
+			ret);
+
+	return ret;
+}
+
+static int wbec_wdt_stop(struct watchdog_device *wdd)
+{
+	struct wbec_watchdog *wdt = watchdog_get_drvdata(wdd);
+	int ret;
+
+	dev_info(wdt->dev,
+		"stop watchdog, but actually EC watchdog is always running, timeout set to %d seconds\n",
+		WBEC_WDG_STOP_TIMEOUT);
+
+	ret = wbec_wdt_set_timeout(wdd, WBEC_WDG_STOP_TIMEOUT);
+	if (ret)
+		return ret;
+
+	// Reset watchdog after timeout updated
+	return wbec_wdt_ping(wdd);
+}
+
+static const struct watchdog_info wbec_watchdog_info = {
+	.options = WDIOF_SETTIMEOUT | WDIOF_KEEPALIVEPING,
+	.identity = "WBEC WDT",
+};
+
+static const struct watchdog_ops wbec_watchdog_ops = {
+	.owner = THIS_MODULE,
+	.start = wbec_wdt_start,
+	.stop = wbec_wdt_stop,
+	.ping = wbec_wdt_ping,
+	.set_timeout = wbec_wdt_set_timeout,
+};
+
+static int wbec_wdt_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	unsigned int timeout;
+	struct wbec *wbec;
+	struct wbec_watchdog *wdt;
+	int ret;
+
+	if (!pdev->dev.parent)
+		return -ENODEV;
+
+	wbec = dev_get_drvdata(dev->parent);
+	if (!wbec)
+		return -EINVAL;
+
+	wdt = devm_kzalloc(dev, sizeof(*wdt), GFP_KERNEL);
+	if (!wdt)
+		return -ENOMEM;
+
+	wdt->dev = dev;
+	wdt->regmap = wbec->regmap;
+
+	wdt->wdtdev.info = &wbec_watchdog_info;
+	wdt->wdtdev.ops = &wbec_watchdog_ops;
+	wdt->wdtdev.min_timeout = WBEC_WDT_MIN_TIMEOUT;
+	wdt->wdtdev.max_timeout = WBEC_WDT_MAX_TIMEOUT;
+	wdt->wdtdev.min_hw_heartbeat_ms = WBEC_RESET_PROTECTION_MS;
+	wdt->wdtdev.timeout = WBEC_WDG_DEFAULT_TIMEOUT;
+	wdt->wdtdev.status = WATCHDOG_NOWAYOUT_INIT_STATUS;
+	wdt->wdtdev.parent = dev;
+
+	watchdog_set_restart_priority(&wdt->wdtdev, 128);
+
+	watchdog_set_drvdata(&wdt->wdtdev, wdt);
+	dev_set_drvdata(dev, &wdt->wdtdev);
+
+	ret = regmap_read(wdt->regmap, WBEC_REG_WDT_TIMEOUT, &timeout);
+	if (ret < 0) {
+		dev_err(wdt->dev, "Failed to read watchdog timeot from wbec");
+		return -ECOMM;
+	}
+	wdt->wdtdev.timeout = timeout;
+
+	/* Set timeout from DT value if available */
+	watchdog_init_timeout(&wdt->wdtdev, 0, dev);
+
+	return devm_watchdog_register_device(dev, &wdt->wdtdev);
+}
+
+static const struct of_device_id wbec_wdt_of_match[] = {
+	{ .compatible = "wirenboard,wbec-watchdog" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wbec_wdt_of_match);
+
+static struct platform_driver wbec_wdt_driver = {
+	.probe = wbec_wdt_probe,
+	.driver = {
+		.name = "wbec-watchdog",
+		.of_match_table = wbec_wdt_of_match,
+	},
+};
+module_platform_driver(wbec_wdt_driver);
+
+MODULE_AUTHOR("Pavel Gasheev <pavel.gasheev@wirenboard.com>");
+MODULE_DESCRIPTION("Wiren Board 7 Embedded Controller Watchdog driver");
+MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:wbec-watchdog");

--- a/include/linux/mfd/wbec.h
+++ b/include/linux/mfd/wbec.h
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: GPL-2.0-only
+ * wbec.c - Wiren Board Embedded Controller MFD driver
+ *
+ * Copyright (c) 2023 Wiren Board LLC
+ *
+ * Author: Pavel Gasheev <pavel.gasheev@wirenboard.com>
+ */
+
+#ifndef __WBEC_H
+#define __WBEC_H
+
+#include <linux/regulator/machine.h>
+#include <linux/regmap.h>
+
+#define WBEC_ID                                             0x3CD2
+
+/* Region INFO: RO */
+#define WBEC_REG_INFO_WBEC_ID                               0x00
+#define WBEC_REG_INFO_BOARD_REV                             0x01
+#define WBEC_REG_INFO_FW_VER_MAJOR                          0x02
+#define WBEC_REG_INFO_FW_VER_MINOR                          0x03
+#define WBEC_REG_INFO_FW_VER_PATCH                          0x04
+#define WBEC_REG_INFO_FW_VER_SUFFIX                         0x05
+#define WBEC_REG_INFO_POWERON_REASON                        0x06
+
+/* Region RTC_TIME: RW */
+#define WBEC_REG_RTC_TIME_SECS_MINS                         0x10
+#define WBEC_REG_RTC_TIME_HOURS_DAYS                        0x11
+#define WBEC_REG_RTC_TIME_WEEKDAYS_MONTHS                   0x12
+#define WBEC_REG_RTC_TIME_YEARS                             0x13
+
+/* Region RTC_ALARM: RW */
+#define WBEC_REG_RTC_ALARM_SECS_MINS                        0x20
+#define WBEC_REG_RTC_ALARM_HOURS_DAYS                       0x21
+#define WBEC_REG_RTC_ALARM_STATUS                           0x22
+   #define WBEC_REG_RTC_ALARM_STATUS_EN_MSK                 BIT(0)
+
+/* Region RTC_CFG: RW */
+#define WBEC_REG_RTC_CFG_OFFSET                             0x30
+   #define WBEC_REG_RTC_CFG_OFFSET_CALM_MASK                GENMASK(8, 0)
+   #define WBEC_REG_RTC_CFG_OFFSET_CALP_BIT                 BIT(15)
+   #define WBEC_REG_RTC_CFG_OFFSET_CALW8_BIT                BIT(14)
+   #define WBEC_REG_RTC_CFG_OFFSET_CALW16_BIT               BIT(13)
+
+/* Region ADC_DATA: RO */
+#define WBEC_REG_ADC_DATA_V_IN                              0x40
+#define WBEC_REG_ADC_DATA_V_3_3                             0x41
+#define WBEC_REG_ADC_DATA_V_5_0                             0x42
+#define WBEC_REG_ADC_DATA_VBUS_CONSOLE                      0x43
+#define WBEC_REG_ADC_DATA_VBUS_NETWORK                      0x44
+#define WBEC_REG_ADC_DATA_TEMP                              0x45
+#define WBEC_REG_ADC_DATA_ADC1                              0x46
+#define WBEC_REG_ADC_DATA_ADC2                              0x47
+#define WBEC_REG_ADC_DATA_ADC3                              0x48
+#define WBEC_REG_ADC_DATA_ADC4                              0x49
+#define WBEC_REG_ADC_DATA_ADC5                              0x4A
+#define WBEC_REG_ADC_DATA_ADC6                              0x4B
+
+/* Region GPIO: RW */
+#define WBEC_REG_GPIO                                       0x80
+   #define WBEC_REG_GPIO_A1_MSK                             BIT(0)
+   #define WBEC_REG_GPIO_A2_MSK                             BIT(1)
+   #define WBEC_REG_GPIO_A3_MSK                             BIT(2)
+   #define WBEC_REG_GPIO_A4_MSK                             BIT(3)
+   #define WBEC_REG_GPIO_V_OUT_MSK                          BIT(4)
+
+/* Region WDT: RW */
+#define WBEC_REG_WDT_TIMEOUT                                0x90
+#define WBEC_REG_WDT_STATUS                                 0x91
+   #define WBEC_REG_WDT_STATUS_RESET_MSK                    BIT(0)
+
+/* Region POWER_CTRL: RW */
+#define WBEC_REG_POWER_CTRL                                 0xA0
+   #define WBEC_REG_POWER_CTRL_OFF_MSK                      BIT(0)
+   #define WBEC_REG_POWER_CTRL_REBOOT_MSK                   BIT(1)
+
+/* Region IRQ_FLAGS: RW */
+#define WBEC_REG_IRQ_FLAGS                                  0xB0
+#define WBEC_REG_IRQ_MSK                                    0xB2
+#define WBEC_REG_IRQ_CLEAR                                  0xB4
+   #define WBEC_REG_IRQ_RTC_ALARM_MSK                       BIT(0)
+   #define WBEC_REG_IRQ_PWROFF_REQ_MSK                      BIT(1)
+
+/* Region PWR_STATUS: RO */
+#define WBEC_REG_PWR_STATUS                                 0xC0
+   #define WBEC_REG_PWR_STATUS_POWERED_FROM_WBMZ_MSK        BIT(0)
+
+
+struct wbec {
+	struct device *dev;
+	struct regmap *regmap;
+	struct dentry *wbec_dir;
+};
+
+#endif

--- a/include/linux/mfd/wbec.h
+++ b/include/linux/mfd/wbec.h
@@ -22,6 +22,7 @@
 #define WBEC_REG_INFO_FW_VER_PATCH                          0x04
 #define WBEC_REG_INFO_FW_VER_SUFFIX                         0x05
 #define WBEC_REG_INFO_POWERON_REASON                        0x06
+#define WBEC_REG_INFO_UID                                   0x07
 
 /* Region RTC_TIME: RW */
 #define WBEC_REG_RTC_TIME_SECS_MINS                         0x10


### PR DESCRIPTION
Второй PR из серии, в которой мы проведём ревью всех изменений в ядро 6.8 для Wiren Board 8.

Здесь все коммиты в драйвера около WBEC. Включил правки из PR #196, #206  и #210 
