### PR TITLE
Linux 6.8 rebase: WB8 RS-485 patches

### DIFF
--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -497,6 +497,8 @@ static enum hrtimer_restart serial8250_em485_handle_stop_tx(struct hrtimer *t);
 void serial8250_clear_and_reinit_fifos(struct uart_8250_port *p)
 {
 	serial8250_clear_fifos(p);
+	/* One byte could be still present in the RX register after clearing the FIFOs */
+	serial_in(p, UART_RX);
 	serial_out(p, UART_FCR, p->fcr);
 }
 EXPORT_SYMBOL_GPL(serial8250_clear_and_reinit_fifos);

--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -81,7 +81,7 @@ static const struct serial8250_config uart_config[] = {
 		.tx_loadsz	= 16,
 		.fcr		= UART_FCR_ENABLE_FIFO | UART_FCR_R_TRIG_10,
 		.rxtrig_bytes	= {1, 4, 8, 14},
-		.flags		= UART_CAP_FIFO,
+		.flags		= UART_CAP_FIFO | UART_CAP_NOTEMT,
 	},
 	[PORT_CIRRUS] = {
 		.name		= "Cirrus",

--- a/include/linux/serial_8250.h
+++ b/include/linux/serial_8250.h
@@ -167,6 +167,7 @@ struct uart_8250_port {
 	/* Serial port overrun backoff */
 	struct delayed_work overrun_backoff;
 	u32 overrun_backoff_time_ms;
+	bool rx_disabled;
 };
 
 static inline struct uart_8250_port *up_to_u8250p(struct uart_port *up)

--- a/include/linux/serial_8250.h
+++ b/include/linux/serial_8250.h
@@ -168,6 +168,7 @@ struct uart_8250_port {
 	struct delayed_work overrun_backoff;
 	u32 overrun_backoff_time_ms;
 	bool rx_disabled;
+	bool skip_break_after_rs485;
 };
 
 static inline struct uart_8250_port *up_to_u8250p(struct uart_port *up)


### PR DESCRIPTION
Шестой PR из серии, в которой мы проведём ревью всех изменений в ядро 6.8 для Wiren Board 8.

Здесь собраны все патчи в драйвер UART, которые нужны были для увеличения стабильности работы RS-485.

Я привязал задачу SOFT-4016 к исправлению вокруг флага NOTEMT, приложил в тикет переписку с одним из авторов кода, чтобы было понятно, куда копать при исправлении.