### PR TITLE
Linux 6.8 rebase: WB8 USB patches

### DIFF
--- a/Documentation/devicetree/bindings/phy/allwinner,sun8i-r40-usb-phy.yaml
+++ b/Documentation/devicetree/bindings/phy/allwinner,sun8i-r40-usb-phy.yaml
@@ -75,6 +75,16 @@ properties:
   usb2_vbus-supply:
     description: Regulator controlling USB2 Host controller
 
+  dr_mode:
+    description: On SoCs with dual route PHY0, port 0 role is controlled by phy, not OTG (peripheral) controller
+    enum:
+      - host
+      - otg
+      - peripheral
+
+  wirenboard,mux-on-id-pin:
+    description: On Wiren Board 7 USB0 is muxed between USB-A connector for host mode and USB-C connector for peripheral mode. The mux is controller by voltage on perihperal connector. The same signal is used as USB ID.
+
 required:
   - "#phy-cells"
   - compatible

--- a/drivers/phy/allwinner/phy-sun4i-usb.c
+++ b/drivers/phy/allwinner/phy-sun4i-usb.c
@@ -140,6 +140,7 @@ struct sun4i_usb_phy_data {
 	int id_det_irq;
 	int vbus_det_irq;
 	int id_det;
+	bool mux_on_id_pin;
 	int vbus_det;
 	struct delayed_work detect;
 	struct usb_role_switch *role_sw;
@@ -257,6 +258,26 @@ static void sun4i_usb_phy_passby(struct sun4i_usb_phy *phy, int enable)
 	writel(reg_value, phy->pmu);
 }
 
+static void sun4i_usb_phy0_set_mode_mux(struct sun4i_usb_phy_data *data)
+{
+	if (!data->mux_on_id_pin)
+		return;
+
+	if (!data->id_det_gpio)
+		return;
+
+	switch (data->dr_mode) {
+		case USB_DR_MODE_HOST:
+			gpiod_direction_output(data->id_det_gpio, 0);
+			break;
+		case USB_DR_MODE_PERIPHERAL:
+			gpiod_direction_output(data->id_det_gpio, 1);
+			break;
+		default:
+			gpiod_direction_input(data->id_det_gpio);
+	}
+}
+
 static int sun4i_usb_phy_init(struct phy *_phy)
 {
 	struct sun4i_usb_phy *phy = phy_get_drvdata(_phy);
@@ -364,6 +385,7 @@ static int sun4i_usb_phy_init(struct phy *_phy)
 		data->id_det = -1;
 		data->vbus_det = -1;
 		queue_delayed_work(system_wq, &data->detect, 0);
+		sun4i_usb_phy0_set_mode_mux(data);
 	}
 
 	return 0;
@@ -519,6 +541,8 @@ static void sun4i_usb_phy0_set_dr_mode(struct sun4i_usb_phy_data *data, int new_
 		dev_info(&data->phys[0].phy->dev, "Changing dr_mode to %d\n", new_mode);
 		data->dr_mode = new_mode;
 	}
+
+	sun4i_usb_phy0_set_mode_mux(data);
 
 	data->id_det = -1; /* Force reprocessing of id */
 	data->force_session_end = true;
@@ -814,6 +838,10 @@ static int sun4i_usb_phy_probe(struct platform_device *pdev)
 		return PTR_ERR(data->id_det_gpio);
 	}
 
+	if (data->id_det_gpio) {
+		data->mux_on_id_pin = of_property_read_bool(np, "wirenboard,mux-on-id-pin");
+	}
+
 	data->vbus_det_gpio = devm_gpiod_get_optional(dev, "usb0_vbus_det",
 						      GPIOD_IN);
 	if (IS_ERR(data->vbus_det_gpio)) {
@@ -928,17 +956,9 @@ static int sun4i_usb_phy_probe(struct platform_device *pdev)
 		phy_set_drvdata(phy->phy, &data->phys[i]);
 	}
 
-	data->id_det_irq = gpiod_to_irq(data->id_det_gpio);
-	if (data->id_det_irq > 0) {
-		ret = devm_request_irq(dev, data->id_det_irq,
-				sun4i_usb_phy0_id_vbus_det_irq,
-				IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING,
-				"usb0-id-det", data);
-		if (ret) {
-			dev_err(dev, "Err requesting id-det-irq: %d\n", ret);
-			return ret;
-		}
-	}
+	// on WB7/WB8 we are going to control id_det GPIO manually in some cases
+	// so it's important to configure it as IRQ and set as output at a later stage
+	data->id_det_irq = -1;
 
 	data->vbus_det_irq = gpiod_to_irq(data->vbus_det_gpio);
 	if (data->vbus_det_irq > 0) {

--- a/drivers/usb/musb/sunxi.c
+++ b/drivers/usb/musb/sunxi.c
@@ -66,12 +66,14 @@
 #define SUNXI_MUSB_FL_HAS_RESET			6
 #define SUNXI_MUSB_FL_NO_CONFIGDATA		7
 #define SUNXI_MUSB_FL_PHY_MODE_PEND		8
+#define SUNXI_MUSB_FL_NO_HOSTMODE		9
 
 struct sunxi_musb_cfg {
 	const struct musb_hdrc_config *hdrc_config;
 	bool has_sram;
 	bool has_reset;
 	bool no_configdata;
+	bool no_host_mode;
 };
 
 /* Our read/write methods need access and do not get passed in a musb ref :| */
@@ -246,11 +248,13 @@ static int sunxi_musb_init(struct musb *musb)
 
 	writeb(SUNXI_MUSB_VEND0_PIO_MODE, musb->mregs + SUNXI_MUSB_VEND0);
 
-	/* Register notifier before calling phy_init() */
-	ret = devm_extcon_register_notifier(glue->dev, glue->extcon,
-					EXTCON_USB_HOST, &glue->host_nb);
-	if (ret)
-		goto error_reset_assert;
+	if (!test_bit(SUNXI_MUSB_FL_NO_HOSTMODE, &glue->flags)) {
+		/* Register notifier before calling phy_init() */
+		ret = devm_extcon_register_notifier(glue->dev, glue->extcon,
+						EXTCON_USB_HOST, &glue->host_nb);
+		if (ret)
+			goto error_reset_assert;
+	}
 
 	ret = phy_init(glue->phy);
 	if (ret)
@@ -698,6 +702,10 @@ static int sunxi_musb_probe(struct platform_device *pdev)
 	switch (usb_get_dr_mode(&pdev->dev)) {
 #if defined CONFIG_USB_MUSB_DUAL_ROLE || defined CONFIG_USB_MUSB_HOST
 	case USB_DR_MODE_HOST:
+		if (test_bit(SUNXI_MUSB_FL_NO_HOSTMODE, &glue->flags)) {
+			dev_err(&pdev->dev, "only support peripheral mode\n");
+			return -EINVAL;
+		}
 		pdata.mode = MUSB_HOST;
 		glue->phy_mode = PHY_MODE_USB_HOST;
 		break;
@@ -710,6 +718,10 @@ static int sunxi_musb_probe(struct platform_device *pdev)
 #endif
 #ifdef CONFIG_USB_MUSB_DUAL_ROLE
 	case USB_DR_MODE_OTG:
+		if (test_bit(SUNXI_MUSB_FL_NO_HOSTMODE, &glue->flags)) {
+			dev_err(&pdev->dev, "only support peripheral mode\n");
+			return -EINVAL;
+		}
 		pdata.mode = MUSB_OTG;
 		glue->phy_mode = PHY_MODE_USB_OTG;
 		break;
@@ -738,6 +750,9 @@ static int sunxi_musb_probe(struct platform_device *pdev)
 
 	if (cfg->no_configdata)
 		set_bit(SUNXI_MUSB_FL_NO_CONFIGDATA, &glue->flags);
+
+	if (cfg->no_host_mode)
+		set_bit(SUNXI_MUSB_FL_NO_HOSTMODE, &glue->flags);
 
 	glue->clk = devm_clk_get(&pdev->dev, NULL);
 	if (IS_ERR(glue->clk)) {
@@ -842,6 +857,13 @@ static const struct sunxi_musb_cfg suniv_f1c100s_musb_cfg = {
 	.no_configdata = true,
 };
 
+static const struct sunxi_musb_cfg sun50i_h616_musb_cfg = {
+	.hdrc_config = &sunxi_musb_hdrc_config_4eps,
+	.has_reset = true,
+	.no_configdata = true,
+	.no_host_mode = true,
+};
+
 static const struct of_device_id sunxi_musb_match[] = {
 	{ .compatible = "allwinner,sun4i-a10-musb",
 	  .data = &sun4i_a10_musb_cfg, },
@@ -853,6 +875,10 @@ static const struct of_device_id sunxi_musb_match[] = {
 	  .data = &sun8i_h3_musb_cfg, },
 	{ .compatible = "allwinner,suniv-f1c100s-musb",
 	  .data = &suniv_f1c100s_musb_cfg, },
+	{ .compatible = "allwinner,sun50i-h616-musb",
+	  .data = &sun50i_h616_musb_cfg, },
+	{ .compatible = "allwinner,sun8i-r40-musb",
+	  .data = &sun50i_h616_musb_cfg, },
 	{}
 };
 MODULE_DEVICE_TABLE(of, sunxi_musb_match);


### PR DESCRIPTION
Одиннадцатый PR из серии, в которой мы проведём ревью всех изменений в ядро 6.8 для Wiren Board 8.

Здесь собраны патчи вокруг USB, в частности, для того, чтобы работало переключение между режимами host и otg