### PR TITLE
wb8: add missing temperature and max voltage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+linux-wb (6.8.0-wb104) stable; urgency=medium
+
+  * add missing axp20x-battery related patches:
+    * set temperature thresholds for battery charging
+    * set max charge voltage from DTS
+    * minor patches to improve charge indicator behavior
+ 
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Tue, 27 Aug 2024 18:04:13 +0500
+
 linux-wb (6.8.0-wb103) stable; urgency=medium
 
   * wb8: add wireguard modules

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -34,6 +34,7 @@
 #define AXP20X_PWR_STATUS_BAT_CURR_DIRECTION	BIT(2)
 
 #define AXP20X_PWR_OP_BATT_PRESENT	BIT(5)
+#define AXP20X_PWR_OP_CHARGING		BIT(6)
 #define AXP20X_PWR_OP_BATT_ACTIVATED	BIT(3)
 
 #define AXP209_FG_PERCENT		GENMASK(6, 0)
@@ -231,16 +232,24 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 		break;
 
 	case POWER_SUPPLY_PROP_STATUS:
+
+		ret = regmap_read(axp20x_batt->regmap, AXP20X_PWR_OP_MODE,
+				  &reg);
+		if (ret)
+			return ret;
+
+		if (reg & AXP20X_PWR_OP_CHARGING) {
+			val->intval = POWER_SUPPLY_STATUS_CHARGING;
+			return 0;
+		}
+
 		ret = axp20x_get_batt_current_ua(axp20x_batt, &val1);
 
 		if (ret)
 			return ret;
 
 		// 3 mA threshold to ignore noise on current shunt
-		if (val1 > 3000) {
-			val->intval = POWER_SUPPLY_STATUS_CHARGING;
-			return 0;
-		} else if (val1 < -3000) {
+		if (val1 < -3000) {
 			val->intval = POWER_SUPPLY_STATUS_DISCHARGING;
 			return 0;
 		}

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -615,6 +615,12 @@ static int axp20x_power_probe(struct platform_device *pdev)
 	if (!power_supply_get_battery_info(axp20x_batt->batt, &info)) {
 		int vmin = info->voltage_min_design_uv;
 		int ccc = info->constant_charge_current_max_ua;
+		int vcv = info->constant_charge_voltage_max_uv;
+
+		if (vcv > 0 && axp20x_batt->data->set_max_voltage(axp20x_batt,
+								  vcv))
+			dev_err(&pdev->dev,
+				"couldn't set charge constant voltage from DT");
 
 		if (vmin > 0 && axp20x_set_voltage_min_design(axp20x_batt,
 							      vmin))

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -196,6 +196,16 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 			return ret;
 
 		val->intval = !!(reg & AXP20X_PWR_OP_BATT_PRESENT);
+
+		// Some PMICs fail to detect disconnected battery. Check volatge to be sure.
+		if (val->intval) {
+			ret = iio_read_channel_processed(axp20x_batt->batt_v,
+							&val1);
+
+			// 500 mV is hopefuly higher than noise and lower than any Li battery
+			if (!ret && val1 < 500)
+				val->intval = 0;
+		}
 		break;
 
 	case POWER_SUPPLY_PROP_STATUS:


### PR DESCRIPTION
Добавил патчи из 5.10, касающиеся записи в PMIC температурных пределов для зарядки и максимального напряжения.

Сюда же попали патчи про флаг Charging, которые были актуальны для WB7. На первый взгляд ничего для wb8 не сломалось.

Сюда НЕ вошёл патч для проверки зарядки supercap, это я хотел бы сначала проверить. Предлагаю сделать это при переезде WB7 на новое ядро. Поставил тикет SOFT-4282 про это