### PR TITLE
Fix battery charging status in 5.10 (WB7)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb170) stable; urgency=medium
+
+  * axp20x: fix charging status logic again, hopefully for the last time
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 05 Sep 2024 10:42:01 +0500
+
 linux-wb (5.10.35-wb169) stable; urgency=medium
 
   * i2c-wbio: cherry-pick i2c bus recovery logic (mv64xxx driver)

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -236,16 +236,6 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 
 	case POWER_SUPPLY_PROP_STATUS:
 
-		ret = regmap_read(axp20x_batt->regmap, AXP20X_PWR_OP_MODE,
-				  &reg);
-		if (ret)
-			return ret;
-
-		if (reg & AXP20X_PWR_OP_CHARGING) {
-			val->intval = POWER_SUPPLY_STATUS_CHARGING;
-			return 0;
-		}
-
 		ret = axp20x_get_batt_current_ua(axp20x_batt, &val1);
 
 		if (ret)
@@ -254,21 +244,20 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 		// 3 mA threshold to ignore noise on current shunt
 		if (val1 < -3000) {
 			val->intval = POWER_SUPPLY_STATUS_DISCHARGING;
-			return 0;
+		} else {
+			// current is positive, it is either charging or full
+			ret = regmap_read(axp20x_batt->regmap, AXP20X_PWR_OP_MODE,
+					  &reg);
+			if (ret)
+				return ret;
+
+			if (reg & AXP20X_PWR_OP_CHARGING) {
+				val->intval = POWER_SUPPLY_STATUS_CHARGING;
+			} else {
+				val->intval = POWER_SUPPLY_STATUS_FULL;
+			}
 		}
 
-		ret = regmap_read(axp20x_batt->regmap, AXP20X_FG_RES, &val1);
-		if (ret)
-			return ret;
-
-		/*
-		 * Fuel Gauge data takes 7 bits but the stored value seems to be
-		 * directly the raw percentage without any scaling to 7 bits.
-		 */
-		if ((val1 & AXP209_FG_PERCENT) == 100)
-			val->intval = POWER_SUPPLY_STATUS_FULL;
-		else
-			val->intval = POWER_SUPPLY_STATUS_NOT_CHARGING;
 		break;
 
 	case POWER_SUPPLY_PROP_HEALTH:


### PR DESCRIPTION
Выяснилось, что флаг из регистра `01h` не совсем корректно отображает состояние зарядки. Скорее он отображает готовность PMIC заряжать батарейку, т.е. что батарейка не заряжена полностью и, судя по всему, PMIC видит напряжение на ACIN.

Максим Томчук считает, что из-за не совсем правильной схемотехники в wb7 PMIC видит напряжение на ACIN, когда батарейка разряжается, потому статус charging устанавливается, когда по факту контроллер работает от батареи.

Максим предложил использовать хитрое сочетание флага из `00h` (который мы ранее отвергли) и `01h`. Вместо флага из `00h` я в коде использовал сразу скорректированное значение тока зарядки на случай, если в флаге в `00h` действительно бывает шум.

Проверил на wb7.4, ведёт себя хорошо. Подробности исследования в тикете.

Также проверил патч в wb8, на первый взгляд тоже выглядит корректно.