### PR TITLE
Feature/3930 fast microsd

### DIFF
--- a/Documentation/devicetree/bindings/regulator/allwinner,h616-mmc-regulator.yaml
+++ b/Documentation/devicetree/bindings/regulator/allwinner,h616-mmc-regulator.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+%YAML 1.2
+---
+$id: "http://devicetree.org/schemas/regulator/allwinner,h616-mmc-regulator.yaml#"
+$schema: "http://devicetree.org/meta-schemas/core.yaml#"
+
+title: Allwinner H616 MMC Regulator
+
+maintainers:
+  - Anton Tarasov <anton.tarasov@wirenboard.com>
+
+description: |
+  This driver supports the built-in MMC voltage regulator of the 
+  Allwinner H616 processor, which allows switching voltage levels 
+  on data lines without using any external regulators. 
+  The regulator is required to switch the voltage from 3.3V to 1.8V 
+  on the data lines to support high-speed SD-UHS modes for MicroSD.
+  Without the regulator, the MicroSD will operate only in slow-modes.
+
+properties:
+  compatible:
+    const: allwinner,h616-mmc-regulator
+
+  syscon:
+    description: Phandle to the system controller (syscon) node.
+
+required:
+  - compatible
+  - syscon
+
+additionalProperties: false
+
+examples:
+  - |
+    mmc_regulator: regulator@0 {
+      compatible = "allwinner,h616-mmc-regulator";
+      syscon = <&syscon>;
+      regulator-name = "h616-mmc-vqmmc";
+      regulator-min-microvolt = <1800000>;
+      regulator-max-microvolt = <3300000>;
+    };
+

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
@@ -344,6 +344,14 @@
 		};
 	};
 
+	h616_vqmmc_regulator: mmc-regulator {
+		compatible = "allwinner,h616-mmc-regulator";
+		syscon = <&pio>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
 	/*
 	Because PMIC battery driver must be enabled at boot time,
 	we have to give it  some battery description to
@@ -1093,6 +1101,8 @@
 };
 
 &pio {
+	/* compatible = "allwinner,sun50i-h616-pinctrl"; */
+	compatible = "allwinner,sun50i-h616-pinctrl", "syscon";
 	vcc-pa-supply = <&reg_dcdc1>;
 	vcc-pc-supply = <&reg_aldo1>;
 	vcc-pd-supply = <&reg_dcdc1>, <&reg_bldo1>;
@@ -1105,7 +1115,16 @@
 	bus-width = <4>;
 	cd-gpios = <&pio PF 6 GPIO_ACTIVE_LOW>;
 	status = "okay";
-	vmmc-supply = <&reg_dcdc1>, <&vdd_sd_power>;
+	vmmc-supply = <&vdd_sd_power>;
+	vqmmc-supply = <&h616_vqmmc_regulator>;
+
+	sd-uhs-sdr104;
+	sd-uhs-sdr50;
+	sd-uhs-sdr25;
+	sd-uhs-sdr12;
+	mmc-ddr-1_8v;
+	/* sd-uhs-ddr50;  // Dont work */
+    max-frequency = <120000000>; // 150Mhz dont work
 };
 
 &mmc2 {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
@@ -1101,7 +1101,6 @@
 };
 
 &pio {
-	/* compatible = "allwinner,sun50i-h616-pinctrl"; */
 	compatible = "allwinner,sun50i-h616-pinctrl", "syscon";
 	vcc-pa-supply = <&reg_dcdc1>;
 	vcc-pc-supply = <&reg_aldo1>;
@@ -1109,6 +1108,10 @@
 	vcc-pe-supply = <&reg_dcdc1>;
 	vcc-pg-supply = <&reg_dcdc1>;
 	vcc-pi-supply = <&reg_dcdc1>;
+
+    mmc0_pins: mmc0-pins {
+        drive-strength = <40>;
+    };
 };
 
 &mmc0 {
@@ -1123,8 +1126,8 @@
 	sd-uhs-sdr25;
 	sd-uhs-sdr12;
 	mmc-ddr-1_8v;
-	/* sd-uhs-ddr50;  // Dont work */
-    max-frequency = <120000000>; // 150Mhz dont work
+    /* sd-uhs-ddr50;  // Dont work */
+    max-frequency = <120000000>; // 150Mhz does not work on some flash drives
 };
 
 &mmc2 {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
@@ -1127,7 +1127,7 @@
 	sd-uhs-sdr12;
 	mmc-ddr-1_8v;
     /* sd-uhs-ddr50;  // Dont work */
-    max-frequency = <120000000>; // 150Mhz does not work on some flash drives
+	max-frequency = <100000000>; // >= 100Mhz does not work on some flash drives
 };
 
 &mmc2 {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -318,6 +318,13 @@
 		};
 	};
 
+	h616_vqmmc_regulator: mmc-regulator {
+		compatible = "allwinner,h616-mmc-regulator";
+		syscon = <&pio>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
 	/*
 	Because PMIC battery driver must be enabled at boot time,
 	we have to give it  some battery description to
@@ -1055,19 +1062,33 @@
 };
 
 &pio {
+	compatible = "allwinner,sun50i-h616-pinctrl", "syscon";
 	vcc-pa-supply = <&reg_dcdc1>;
 	vcc-pc-supply = <&reg_aldo1>;
 	vcc-pd-supply = <&reg_dcdc1>, <&reg_bldo1>;
 	vcc-pe-supply = <&reg_dcdc1>;
 	vcc-pg-supply = <&reg_dcdc1>;
 	vcc-pi-supply = <&reg_dcdc1>;
+
+	mmc0_pins: mmc0-pins {
+		drive-strength = <40>;
+	};
 };
 
 &mmc0 {
 	bus-width = <4>;
 	cd-gpios = <&pio PF 6 GPIO_ACTIVE_LOW>;
 	status = "okay";
-	vmmc-supply = <&reg_dcdc1>, <&vdd_sd_power>;
+	vmmc-supply = <&vdd_sd_power>;
+	vqmmc-supply = <&h616_vqmmc_regulator>;
+
+	sd-uhs-sdr104;
+	sd-uhs-sdr50;
+	sd-uhs-sdr25;
+	sd-uhs-sdr12;
+	mmc-ddr-1_8v;
+	/* sd-uhs-ddr50;  // Dont work */
+	max-frequency = <120000000>; // 150Mhz does not work on some flash drives
 };
 
 &mmc2 {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -1088,7 +1088,7 @@
 	sd-uhs-sdr12;
 	mmc-ddr-1_8v;
 	/* sd-uhs-ddr50;  // Dont work */
-	max-frequency = <120000000>; // 150Mhz does not work on some flash drives
+	max-frequency = <100000000>; // >= 100Mhz does not work on some flash drives
 };
 
 &mmc2 {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb109) stable; urgency=medium
+
+  * Change the frequency of the MicroSD bus to 100 MHz
+  * Set the maximum power for the MicroSD pins.
+  * Ported the MicroSD settings to branch 8.5.
+
+ -- Anton <anton.tarasov@wirenboard.com>  Tue, 12 Nov 2024 09:40:37 +0300
+
 linux-wb (6.8.0-wb108) stable; urgency=medium
 
   * wb8: compile CAN module into the kernel

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -1683,4 +1683,16 @@ config REGULATOR_QCOM_LABIBB
 	  boost regulator and IBB can be used as a negative boost regulator
 	  for LCD display panel.
 
+config REGULATOR_H616_MMC
+    bool "Allwinner H616 MMC power regulator support"
+	default ARCH_SUNXI
+    help
+      This driver supports the PMMC regulator found in Allwinner sunxi SoCs,
+      allowing control over the IO voltage levels.
+
+      Say Y here if you need to control the IO voltage of pin banks
+      via the PIO controller.
+
+      If unsure, say N.
+
 endif

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -1687,11 +1687,15 @@ config REGULATOR_H616_MMC
     bool "Allwinner H616 MMC power regulator support"
 	default ARCH_SUNXI
     help
-      This driver supports the PMMC regulator found in Allwinner sunxi SoCs,
-      allowing control over the IO voltage levels.
-
-      Say Y here if you need to control the IO voltage of pin banks
-      via the PIO controller.
+      This driver supports the built-in MMC voltage regulator of the 
+      Allwinner H616 processor, which allows switching voltage levels 
+      on data lines without using any external regulators. 
+      The regulator is required to switch the voltage from 3.3V to 1.8V 
+      on the data lines to support high-speed SD-UHS modes for MicroSD.
+      Without the regulator, the MicroSD will operate only in "slow" modes.
+        
+      Select "Yes" here if you want to use the built-in regulator to 
+      support high-speed UHS modes.
 
       If unsure, say N.
 

--- a/drivers/regulator/Makefile
+++ b/drivers/regulator/Makefile
@@ -197,5 +197,6 @@ obj-$(CONFIG_REGULATOR_WM831X) += wm831x-ldo.o
 obj-$(CONFIG_REGULATOR_WM8350) += wm8350-regulator.o
 obj-$(CONFIG_REGULATOR_WM8400) += wm8400-regulator.o
 obj-$(CONFIG_REGULATOR_WM8994) += wm8994-regulator.o
+obj-$(CONFIG_REGULATOR_H616_MMC) += h616-mmc-regulator.o
 
 ccflags-$(CONFIG_REGULATOR_DEBUG) += -DDEBUG

--- a/drivers/regulator/h616-mmc-regulator.c
+++ b/drivers/regulator/h616-mmc-regulator.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0+
+// Copyright (c) 2024 Anton Tarasov <anton.tarasov@wirenboard.com>
+//
+// Allwinner H616 MMC Regulator Driver
+#include <linux/io.h>
+#include <linux/module.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/regulator/of_regulator.h>
+#include <linux/platform_device.h>
+#include <linux/io.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/regmap.h>
+#include <linux/mfd/syscon.h>
+#include <linux/mod_devicetable.h>
+#include <linux/of_address.h>
+
+#define VSEL_REG   0x0350  // Voltage selection register
+#define VSEL_MASK  0x1     // Voltage selection mask (bit 0)
+
+#define MOD_SEL_REG   0x0340  // Withstand voltage selection register
+#define MOD_SEL_MASK  0x20    // Withstand voltage selection mask (bit 5)
+
+static const unsigned int h616_regulator_voltages[] = {
+	1800000, // 1.8V
+	3300000, // 3.3V
+};
+
+static int h616_regulator_set_voltage(struct regulator_dev *rdev,
+                                      int min_uV, int max_uV,
+                                      unsigned int *selector)
+{
+    struct regmap *regmap = rdev_get_regmap(rdev);
+    int ret;
+
+    *selector = regulator_map_voltage_iterate(rdev, min_uV, max_uV);
+    if (*selector < 0)
+        return -EINVAL;
+
+    // Set the withstand voltage level
+    ret = regmap_update_bits(regmap, MOD_SEL_REG, MOD_SEL_MASK, 
+            (*selector == 0) ? MOD_SEL_MASK : 0);
+    if (ret)
+        return ret;
+    
+    // Update the main voltage level
+    ret = regmap_update_bits(regmap, VSEL_REG, VSEL_MASK, *selector);
+    return ret;
+
+    return 0;
+}
+
+static const struct regulator_ops h616_regulator_ops = {
+	.list_voltage = regulator_list_voltage_table,
+	.map_voltage = regulator_map_voltage_iterate,
+	.get_voltage_sel = regulator_get_voltage_sel_regmap,
+    .set_voltage = h616_regulator_set_voltage,
+};
+
+static const struct regulator_desc h616_regulator_desc = {
+    .name = "h616-mmc-vqmmc",
+    .of_match = "allwinner,h616-mmc-regulator",
+	.type = REGULATOR_VOLTAGE,
+	.owner = THIS_MODULE,
+    .ops = &h616_regulator_ops,
+	.n_voltages = 2,
+	.volt_table = h616_regulator_voltages,
+	.vsel_reg = VSEL_REG,
+	.vsel_mask = VSEL_MASK,
+};
+
+static int h616_regulator_probe(struct platform_device *pdev)
+{
+
+    struct regulator_config config = {};
+    struct regulator_desc *desc;
+    struct regmap *regmap;
+
+    regmap = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "syscon");
+    if (IS_ERR(regmap))
+        return PTR_ERR(regmap);
+
+    desc = devm_kmemdup(&pdev->dev, &h616_regulator_desc, sizeof(*desc), GFP_KERNEL);
+    if (!desc)
+        return -ENOMEM;
+
+    config.dev = &pdev->dev;
+    config.of_node = pdev->dev.of_node;
+    config.regmap = regmap;
+
+    config.init_data = of_get_regulator_init_data(&pdev->dev, 
+            pdev->dev.of_node, &h616_regulator_desc);
+    if (!config.init_data) 
+        return -ENOMEM;
+
+    if (IS_ERR(devm_regulator_register(&pdev->dev, desc, &config)))
+        return PTR_ERR(devm_regulator_register(&pdev->dev, desc, &config));
+
+    return 0;
+}
+
+static const struct of_device_id h616_regulator_of_match[] = {
+    { .compatible = "allwinner,h616-mmc-regulator", },
+	{},
+};
+MODULE_DEVICE_TABLE(of, h616_regulator_of_match);
+
+static struct platform_driver h616_regulator_driver = {
+    .probe = h616_regulator_probe,
+    .driver = {
+        .name = "h616-mmc-regulator",
+        .of_match_table = h616_regulator_of_match,
+    },
+};
+
+module_platform_driver(h616_regulator_driver);
+
+MODULE_AUTHOR("Anton Tarasov <anton.tarasov@wirenboard.com>");
+MODULE_DESCRIPTION("H616 MMC Regulator Driver");
+MODULE_LICENSE("GPL");
+

--- a/drivers/regulator/h616-mmc-regulator.c
+++ b/drivers/regulator/h616-mmc-regulator.c
@@ -17,10 +17,10 @@
 #include <linux/of_address.h>
 
 #define VSEL_REG   0x0350  // Voltage selection register
-#define VSEL_MASK  0x1     // Voltage selection mask (bit 0)
+#define VSEL_MASK  0x1	 // Voltage selection mask (bit 0)
 
 #define MOD_SEL_REG   0x0340  // Withstand voltage selection register
-#define MOD_SEL_MASK  0x20    // Withstand voltage selection mask (bit 5)
+#define MOD_SEL_MASK  0x20	// Withstand voltage selection mask (bit 5)
 
 static const unsigned int h616_regulator_voltages[] = {
 	1800000, // 1.8V
@@ -28,42 +28,42 @@ static const unsigned int h616_regulator_voltages[] = {
 };
 
 static int h616_regulator_set_voltage(struct regulator_dev *rdev,
-                                      int min_uV, int max_uV,
-                                      unsigned int *selector)
+									  int min_uV, int max_uV,
+									  unsigned int *selector)
 {
-    struct regmap *regmap = rdev_get_regmap(rdev);
-    int ret;
+	struct regmap *regmap = rdev_get_regmap(rdev);
+	int ret;
 
-    *selector = regulator_map_voltage_iterate(rdev, min_uV, max_uV);
-    if (*selector < 0)
-        return -EINVAL;
+	*selector = regulator_map_voltage_iterate(rdev, min_uV, max_uV);
+	if (*selector < 0)
+		return -EINVAL;
 
-    // Set the withstand voltage level
-    ret = regmap_update_bits(regmap, MOD_SEL_REG, MOD_SEL_MASK, 
-            (*selector == 0) ? MOD_SEL_MASK : 0);
-    if (ret)
-        return ret;
-    
-    // Update the main voltage level
-    ret = regmap_update_bits(regmap, VSEL_REG, VSEL_MASK, *selector);
-    return ret;
+	// Set the withstand voltage level
+	ret = regmap_update_bits(regmap, MOD_SEL_REG, MOD_SEL_MASK,
+			(*selector == 0) ? MOD_SEL_MASK : 0);
+	if (ret)
+		return ret;
 
-    return 0;
+	// Update the main voltage level
+	ret = regmap_update_bits(regmap, VSEL_REG, VSEL_MASK, *selector);
+	return ret;
+
+	return 0;
 }
 
 static const struct regulator_ops h616_regulator_ops = {
 	.list_voltage = regulator_list_voltage_table,
 	.map_voltage = regulator_map_voltage_iterate,
 	.get_voltage_sel = regulator_get_voltage_sel_regmap,
-    .set_voltage = h616_regulator_set_voltage,
+	.set_voltage = h616_regulator_set_voltage,
 };
 
 static const struct regulator_desc h616_regulator_desc = {
-    .name = "h616-mmc-vqmmc",
-    .of_match = "allwinner,h616-mmc-regulator",
+	.name = "h616-mmc-vqmmc",
+	.of_match = "allwinner,h616-mmc-regulator",
 	.type = REGULATOR_VOLTAGE,
 	.owner = THIS_MODULE,
-    .ops = &h616_regulator_ops,
+	.ops = &h616_regulator_ops,
 	.n_voltages = 2,
 	.volt_table = h616_regulator_voltages,
 	.vsel_reg = VSEL_REG,
@@ -73,45 +73,45 @@ static const struct regulator_desc h616_regulator_desc = {
 static int h616_regulator_probe(struct platform_device *pdev)
 {
 
-    struct regulator_config config = {};
-    struct regulator_desc *desc;
-    struct regmap *regmap;
+	struct regulator_config config = {};
+	struct regulator_desc *desc;
+	struct regmap *regmap;
 
-    regmap = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "syscon");
-    if (IS_ERR(regmap))
-        return PTR_ERR(regmap);
+	regmap = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "syscon");
+	if (IS_ERR(regmap))
+		return PTR_ERR(regmap);
 
-    desc = devm_kmemdup(&pdev->dev, &h616_regulator_desc, sizeof(*desc), GFP_KERNEL);
-    if (!desc)
-        return -ENOMEM;
+	desc = devm_kmemdup(&pdev->dev, &h616_regulator_desc, sizeof(*desc), GFP_KERNEL);
+	if (!desc)
+		return -ENOMEM;
 
-    config.dev = &pdev->dev;
-    config.of_node = pdev->dev.of_node;
-    config.regmap = regmap;
+	config.dev = &pdev->dev;
+	config.of_node = pdev->dev.of_node;
+	config.regmap = regmap;
 
-    config.init_data = of_get_regulator_init_data(&pdev->dev, 
-            pdev->dev.of_node, &h616_regulator_desc);
-    if (!config.init_data) 
-        return -ENOMEM;
+	config.init_data = of_get_regulator_init_data(&pdev->dev,
+			pdev->dev.of_node, &h616_regulator_desc);
+	if (!config.init_data)
+		return -ENOMEM;
 
-    if (IS_ERR(devm_regulator_register(&pdev->dev, desc, &config)))
-        return PTR_ERR(devm_regulator_register(&pdev->dev, desc, &config));
+	if (IS_ERR(devm_regulator_register(&pdev->dev, desc, &config)))
+		return PTR_ERR(devm_regulator_register(&pdev->dev, desc, &config));
 
-    return 0;
+	return 0;
 }
 
 static const struct of_device_id h616_regulator_of_match[] = {
-    { .compatible = "allwinner,h616-mmc-regulator", },
+	{ .compatible = "allwinner,h616-mmc-regulator", },
 	{},
 };
 MODULE_DEVICE_TABLE(of, h616_regulator_of_match);
 
 static struct platform_driver h616_regulator_driver = {
-    .probe = h616_regulator_probe,
-    .driver = {
-        .name = "h616-mmc-regulator",
-        .of_match_table = h616_regulator_of_match,
-    },
+	.probe = h616_regulator_probe,
+	.driver = {
+		.name = "h616-mmc-regulator",
+		.of_match_table = h616_regulator_of_match,
+	},
 };
 
 module_platform_driver(h616_regulator_driver);
@@ -120,3 +120,4 @@ MODULE_AUTHOR("Anton Tarasov <anton.tarasov@wirenboard.com>");
 MODULE_DESCRIPTION("H616 MMC Regulator Driver");
 MODULE_LICENSE("GPL");
 
+/* vim: noexpandtab ts=4 sts=4 sw=4 */


### PR DESCRIPTION
Реализовал драйвер для MicroSD, который задействует встроенных регулятор напряжения H616, для работы в скоростных режимах SD-UHS.

На части протестированных флешках не работает на скоростях 150Мгц (ошибка при записи из буфера на флешку). По-этому урезал до 120Мгц - на ней работает стабильно.

Выдает:
```
root@wirenboard-AGQWPRTR:~# cat /sys/kernel/debug/mmc1/ios 
clock:		120000000 Hz
actual clock:	120000000 Hz
vdd:		21 (3.3 ~ 3.4 V)
bus mode:	2 (push-pull)
chip select:	0 (don't care)
power mode:	2 (on)
bus width:	2 (4 bits)
timing spec:	6 (sd uhs SDR104)
signal voltage:	1 (1.80 V)
driver type:	0 (driver type B)
```

```
root@wirenboard-AGQWPRTR:~# dd if=/dev/random of=/dev/mmcblk1 status=progress bs=1M
4057989120 байт (4,1 GB, 3,8 GiB) скопирован, 129 s, 31,4 MB/s^C
3881+0 записей получено
3881+0 записей отправлено
4069523456 байт (4,1 GB, 3,8 GiB) скопирован, 142,262 s, 28,6 MB/s
```

```
root@wirenboard-AGQWPRTR:~# dd if=/dev/mmcblk1 of=/dev/null status=progress bs=1M
4294967296 байт (4,3 GB, 4,0 GiB) скопирован, 79 s, 54,4 MB/s^C
4104+0 записей получено
4103+0 записей отправлено
4302307328 байт (4,3 GB, 4,0 GiB) скопирован, 79,9615 s, 53,8 MB/s
```

Скорость зависит от флешки и это максимум из тех, что у меня есть в наличии.