### PR TITLE
Feature/wb8 wbio recover

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
@@ -656,8 +656,12 @@
 
 /* WBIO I2C */
 &i2c3 {
-	pinctrl-names = "default";
+	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&i2c3_pa_pins>;
+	pinctrl-1 = <&i2c3_gpio>;
+
+	scl-gpios = <&pio PA 10 GPIO_ACTIVE_HIGH>; /* PA10 */
+	sda-gpios = <&pio PA 11 GPIO_ACTIVE_HIGH>; /* PA11 */
 
 	status = "okay";
 };
@@ -1148,10 +1152,17 @@
 		drive-strength = <40>;
 	};
 
+	/delete-node/ i2c3-ph-pins;
+
 	i2c3_pa_pins: i2c3-pa-pins {
 		pins = "PA10", "PA11";
 		function = "i2c3";
 		drive-strength = <40>;
+	};
+
+	i2c3_gpio: i2c3-gpio-pins {
+		pins = "PA10", "PA11";
+		function = "gpio_out";
 	};
 };
 

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -617,8 +617,12 @@
 
 /* WBIO I2C */
 &i2c3 {
-	pinctrl-names = "default";
+	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&i2c3_pa_pins>;
+	pinctrl-1 = <&i2c3_gpio>;
+
+	scl-gpios = <&pio PA 10 GPIO_ACTIVE_HIGH>; /* PA10 */
+	sda-gpios = <&pio PA 11 GPIO_ACTIVE_HIGH>; /* PA11 */
 
 	status = "okay";
 };
@@ -1110,10 +1114,17 @@
 		drive-strength = <40>;
 	};
 
+	/delete-node/ i2c3-ph-pins;
+
 	i2c3_pa_pins: i2c3-pa-pins {
 		pins = "PA10", "PA11";
 		function = "i2c3";
 		drive-strength = <40>;
+	};
+
+	i2c3_gpio: i2c3-gpio-pins {
+		pins = "PA10", "PA11";
+		function = "gpio_out";
 	};
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb110) stable; urgency=medium
+
+  * sun50i-h616 pinctrl: disable strict mode
+  * wb84, wb85 dtsi: add wbio i2c-recovery pins
+  * i2c-mv64xxx: fix hard lockup on external polling, when performing i2c bus recovery
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 10 Oct 2024 15:43:21 +0300
+
 linux-wb (6.8.0-wb109) stable; urgency=medium
 
   * wb8: usb printer support

--- a/drivers/pinctrl/sunxi/pinctrl-sun50i-h616.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sun50i-h616.c
@@ -876,6 +876,7 @@ static const struct sunxi_pinctrl_desc h616_pinctrl_data = {
 	.irq_banks = ARRAY_SIZE(h616_irq_bank_map),
 	.irq_bank_map = h616_irq_bank_map,
 	.irq_read_needs_mux = true,
+	.disable_strict_mode = true,
 	.io_bias_cfg_variant = BIAS_VOLTAGE_PIO_POW_MODE_CTL,
 };
 


### PR DESCRIPTION
i2c bus recovery наконец-то работает!

завелось через generic scl recovery (в i2c-core); для этого надо: отдельный pinctrl на gpio (а для этого - отключили strcit mode, чтобы иметь одни и те же пины в разных режимах)

ловил hard lockup и kernel panic после i2c recovery. Путём экспериментов с [ардуиной](https://github.com/wirenboard/wb-scripts-storage/tree/main/i2c_stuck_emulation) выяснилось, что в lockup-е виноват опрос, пока происходит recovery; решение - отключаем на это время fsm драйвера


пруфы, что всё работает на настоящем wbio (и локапа нет; опрос продолжается)
![image_2024-10-10_16-22-45](https://github.com/user-attachments/assets/ef4cac8d-28af-46a8-900f-78082103b883)

потыкать можно, вставив-сконфигурировав модулёк и замыкая sda на землю
