### PR TITLE
Feature/wb7 wbio recover

### DIFF
--- a/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard72x.dtsi
@@ -348,6 +348,12 @@
 
 /* WBIO I2C */
 &i2c1 {
+	pinctrl-names = "default", "gpio";
+	pinctrl-1 = <&i2c1_pins_gpio>;
+
+	scl-gpios = <&pio 1 18 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&pio 1 19 GPIO_ACTIVE_HIGH>;
+
 	status = "okay";
 };
 
@@ -632,6 +638,11 @@
 	pwm_ch7_pb_pins: pwm-ch7-pb-pins {
 		pins = "PB10";
 		function = "pwm";
+	};
+
+	i2c1_pins_gpio: i2c1-pins-gpio {
+		pins = "PB18", "PB19";
+		function = "gpio_out";
 	};
 };
 

--- a/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/sun8i-r40-wirenboard74x.dtsi
@@ -413,6 +413,12 @@
 
 /* WBIO I2C */
 &i2c1 {
+	pinctrl-names = "default", "gpio";
+	pinctrl-1 = <&i2c1_pins_gpio>;
+
+	scl-gpios = <&pio 1 18 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&pio 1 19 GPIO_ACTIVE_HIGH>;
+
 	status = "okay";
 };
 
@@ -763,6 +769,11 @@
 	spi2_cs0_pb_pin: spi2-cs0-pb-pin {
 		pins = "PB14";
 		function = "spi2";
+	};
+
+	i2c1_pins_gpio: i2c1-pins-gpio {
+		pins = "PB18", "PB19";
+		function = "gpio_out";
 	};
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb171) stable; urgency=medium
+
+  * wb7 dts: add i2c-wbio-recovery pins
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 10 Oct 2024 18:48:19 +0300
+
 linux-wb (5.10.35-wb170) stable; urgency=medium
 
   * axp20x: fix charging status logic again, hopefully for the last time


### PR DESCRIPTION
раз занимался i2c-recovery на wb8 - посмотрел, что с этим на wb7 и 6

на wb7 завелось сейчас:
![image_2024-10-10_18-43-24](https://github.com/user-attachments/assets/cb173502-5a75-4146-9ebb-c45249c11c8c)

на wb6 работало уже:
![image_2024-10-10_19-25-34](https://github.com/user-attachments/assets/16ed4758-767f-43cb-9fb1-72b76b38c4e0)
