### PR TITLE
Feature/name flashing port

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8-bootlet.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8-bootlet.dts
@@ -64,11 +64,16 @@
 	};
 };
 
-&ohci3 {
+&ehci3 {
 	status = "okay";
+
+	/* we need to know (in bootlet), where usb-flashing-drive is connected */
+	compatible = "wirenboard,usb-flashing-drive",
+					"allwinner,sun50i-h616-ehci",
+					"generic-ehci";
 };
 
-&ehci3 {
+&ohci3 {
 	status = "okay";
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb120) stable; urgency=medium
+
+  * wb8-bootlet: name usb-flashing-port
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 28 Nov 2024 18:01:03 +0300
+
 linux-wb (6.8.0-wb119) stable; urgency=medium
 
   * wb8.5.1m: change default rtc to rtc_onboard_txco


### PR DESCRIPTION
ковыряясь в initram и околопрошивательных режимах, появилась идея ускорения прошивки: чтобы не ждать USB-флешку 10с, смотрим, воткнуто ли что-нибудь в USB-A порт

=> этот самый USB-A порт надо как-то доступно из initram обозвать