### PR TITLE
Bugfix/wb851m rtc

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
@@ -45,16 +45,18 @@
 
 /*
  * Metall-body WB:
- * - disable WBIO
- * - enable addtitonal rtc "whwave,sd3078"
+ * - no WBIO
+ * - enable addtitonal rtc "whwave,sd3078" on WBIO bus (instead of crypto-chip bus; check crypto-chip errata for reasons)
  * - additional rtc is a default one
  */
-&rtc_onboard_txco {
-	status = "okay";
-};
+
+/delete-node/ &rtc_onboard_txco;
 
 &i2c3 {
-	status = "disabled";
+	rtc_onboard_txco: rtc@32 {
+		compatible = "whwave,sd3078";
+		reg = <0x32>;
+	};
 };
 
 &aliases {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb121) stable; urgency=medium
+
+  * wb8m: move rtc from atecc bus to wbio
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 04 Dec 2024 14:15:16 +0300
+
 linux-wb (6.8.0-wb120) stable; urgency=medium
 
   * wb8-bootlet: name usb-flashing-port


### PR DESCRIPTION
тыкая WB851m, инженеры заметили, что что-то новый-модный-rtc как-то плохо работает

порисёчили - виноват крипточип, сидящий на той же шине. У него в еррате написано что-то вроде "оставьте его на шине одного" => перенесли rtc-чип на шину WBIO (пустую; wbio там не будет)

инженеры потыкали - вроде ок