### PR TITLE
Bugfix/wb851m rtc

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard84x.dtsi
@@ -44,10 +44,8 @@
 		i2c3 = &i2c_wbmz;
 		rtc0 = &rtc_onboard;
 		rtc1 = &rtc;
-		rtc2 = &rtc_onboard_txco;
 		wbc_modem = &wbc_modem;
 		rtc_onboard = &rtc_onboard;
-		rtc_onboard_txco = &rtc_onboard_txco;
 	};
 
 	wirenboard {
@@ -400,7 +398,7 @@
 		};
 	};
 
-	/* ATECC + optional TCXO RTC */
+	/* ATECC (should be alone on the bus; check errata) */
 	i2c_atecc_rtc: i2c_atecc_rtc {
 		compatible = "i2c-gpio";
 
@@ -411,12 +409,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		status = "okay";
-
-		rtc_onboard_txco: rtc@32 {
-			compatible = "whwave,sd3078";
-			reg = <0x32>;
-			status = "disabled";
-		};
 	};
 
 	i2c_wbec: i2c_wbec {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
@@ -50,8 +50,6 @@
  * - additional rtc is a default one
  */
 
-/delete-node/ &rtc_onboard_txco;
-
 &i2c3 {
 	rtc_onboard_txco: rtc@32 {
 		compatible = "whwave,sd3078";

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851m.dts
@@ -45,16 +45,18 @@
 
 /*
  * Metall-body WB:
- * - disable WBIO
- * - enable addtitonal rtc "whwave,sd3078"
+ * - no WBIO
+ * - enable addtitonal rtc "whwave,sd3078" on WBIO bus (instead of crypto-chip bus; check crypto-chip errata for reasons)
  * - additional rtc is a default one
  */
-&rtc_onboard_txco {
-	status = "okay";
-};
+
+/delete-node/ &rtc_onboard_txco;
 
 &i2c3 {
-	status = "disabled";
+	rtc_onboard_txco: rtc@32 {
+		compatible = "whwave,sd3078";
+		reg = <0x32>;
+	};
 };
 
 &aliases {

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -43,10 +43,8 @@
 		i2c2 = &i2c_atecc_rtc;  // ATECC must be on i2c2 for compatibility
 		rtc0 = &rtc_onboard;
 		rtc1 = &rtc;
-		rtc2 = &rtc_onboard_txco;
 		wbc_modem = &wbc_modem;
 		rtc_onboard = &rtc_onboard;
-		rtc_onboard_txco = &rtc_onboard_txco;
 	};
 
 	wirenboard {
@@ -333,7 +331,7 @@
 		status = "okay";
 	};
 
-	/* ATECC + optional TCXO RTC */
+	/* ATECC (should be alone on the bus; check errata) */
 	i2c_atecc_rtc: i2c_atecc_rtc {
 		compatible = "i2c-gpio";
 
@@ -344,12 +342,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		status = "okay";
-
-		rtc_onboard_txco: rtc@32 {
-			compatible = "whwave,sd3078";
-			reg = <0x32>;
-			status = "disabled";
-		};
 	};
 
 	i2c_wbec: i2c_wbec {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb121) stable; urgency=medium
+
+  * wb8m: move rtc from crypto-chip bus to wbio bus
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 04 Dec 2024 14:15:16 +0300
+
 linux-wb (6.8.0-wb120) stable; urgency=medium
 
   * wb8-bootlet: name usb-flashing-port


### PR DESCRIPTION
тыкая WB851m, инженеры заметили, что что-то новый-модный-rtc как-то плохо работает

порисёчили - виноват крипточип, сидящий на той же шине. У него в еррате написано что-то вроде "оставьте его на шине одного" => перенесли rtc-чип на шину WBIO (пустую; wbio там не будет)

инженеры потыкали - вроде ок
