### PR TITLE
Feature/mcp pass error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb126) stable; urgency=medium
+
+  * pinctrl-mcp23s08: pass error on unsuccessful regmap_read
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 23 Jan 2025 21:03:21 +0300
+
 linux-wb (6.8.0-wb125) stable; urgency=medium
 
   * implement a MicroSD driver that utilizes the built-in voltage regulator

--- a/drivers/pinctrl/pinctrl-mcp23s08.c
+++ b/drivers/pinctrl/pinctrl-mcp23s08.c
@@ -298,7 +298,7 @@ static int mcp23s08_get(struct gpio_chip *chip, unsigned offset)
 	/* REVISIT reading this clears any IRQ ... */
 	ret = mcp_read(mcp, MCP_GPIO, &status);
 	if (ret < 0)
-		status = 0;
+		status = ret;
 	else {
 		mcp->cached_gpio = status;
 		status = !!(status & (1 << offset));


### PR DESCRIPTION
проблема: в драйвере mcp23s08 ошибка чтения регмапа не прокидывалась никуда наружу => ioctl чтения был удачным даже, если модуль физически отсоединен

для ядра 5.10 мы такое [уже чинили](https://github.com/wirenboard/linux/pull/172) - черри-пикнул и в 6.8