### PR TITLE
Feature/wb8 phy addr

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -1184,6 +1184,7 @@
 
 			reset-gpios = <&pio PI 4 GPIO_ACTIVE_LOW>;
 			reset-delay-us = <50000>;
+			reset-post-delay-us = <150000>;  // Datasheet "Power On and PHY Reset Sequence"
 
 			ext_rmii_phy0: ethernet-phy {
 				compatible = "ethernet-phy-ieee802.3-c22";
@@ -1200,6 +1201,7 @@
 
 			reset-gpios = <&pio PI 8 GPIO_ACTIVE_LOW>;
 			reset-delay-us = <50000>;
+			reset-post-delay-us = <150000>;  // Datasheet "Power On and PHY Reset Sequence"
 
 			ext_rmii_phy1: ethernet-phy {
 				compatible = "ethernet-phy-ieee802.3-c22";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb134) stable; urgency=medium
+
+  * wb8 dts: add eth phy reset-post-delay-us: 150000 (as datasheet says)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 08 Apr 2025 13:13:14 +0300
+
 linux-wb (6.8.0-wb133) stable; urgency=medium
 
   * Add a delay before turning i2c on bus error


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
на производстве начались проблемы с тестом ethernet. Посмотрели-раскопали: иногда (на 10-100 ребут одного и того же wb8), wb не получает IP, а в dmesg примерно такое:  mdio_bus gpio-0: ethernet-phy has invalid PHY address

попробовали прописать в dts адрес phy - чет не заработало => читал даташит на чип - увидел картиночку:
![image_2025-04-08_15-11-47](https://github.com/user-attachments/assets/458fbb95-d343-4a18-bdda-6faf62c528a6)

-> включил делей 150мс после дергания ресетом

___________________________________
**Что поменялось для пользователей:**
никак; врядли кто-то такое вообще замечал

___________________________________
**Как проверял/а:**
у тест-сьютеров есть чудо-скрипт, дергающий питание на wb и смотрящий, что интернет завелся. Погоняли на нем 100+ раз один вб - не стреляло

