### PR TITLE
Fix RTL8733BU client not connecting when it is the only interface bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb138) stable; urgency=medium
+
+  * wb8: fix rtl8733bu client not connecting when it is the only interface bug
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Sat, 31 May 2025 08:16:02 +0300
+
 linux-wb (6.8.0-wb137) stable; urgency=medium
 
   * wb8: disallow scan on buddy interface for rtl8733bu if configured as client


### PR DESCRIPTION
Исправил ошибку, из-за которой драйвер RTL8733BU в режиме клиента не мог подключиться к сети, если это единственный интерфейс, немного подробнее здесь: https://github.com/wirenboard/rtl8733bu/pull/18