### PR TITLE
rtl8733bu: move BusyTraffic log messages to debug level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb178) stable; urgency=medium
+
+  * rtl8733bu: move BusyTraffic log messages to debug level
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 07 Jul 2025 14:11:00 +0400
+
 linux-wb (5.10.35-wb177) stable; urgency=medium
 
   * wb7: fix rtl8733bu client not connecting when it is the only interface bug


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* https://github.com/wirenboard/rtl8733bu/pull/19

___________________________________
**Что поменялось для пользователей:**
убирает BusyTraffic спам в dmesg.

___________________________________
**Как проверял/а:**
на wb, смотрим в dmesg

