### PR TITLE
Features/soft 5558 hdmi overlay

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851.dts
@@ -54,15 +54,6 @@
 
 };
 
-&de {
-	status = "okay";
-};
-
-&hdmi {
-	hvcc-supply = <&reg_aldo1>;
-	status = "okay";
-};
-
 &hdmi_out {
 	hdmi_out_con: endpoint {
 		remote-endpoint = <&hdmi_con_in>;

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
@@ -824,6 +824,7 @@
 			phys = <&hdmi_phy>;
 			phy-names = "phy";
 			status = "disabled";
+			hvcc-supply = <&reg_aldo1>;
 
 			ports {
 				#address-cells = <1>;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb141) stable; urgency=medium
+
+  * wb8: Disabled HDMI by default so that it could be enabled in overlays later
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Wed, 23 Jul 2025 11:13:33 +0300
+
 linux-wb (6.8.0-wb140) stable; urgency=medium
 
   * wb8: add netfilter modules


### PR DESCRIPTION
Отключил HDMI по дефолту, чтобы потом он мог быть включен через оверлей.
___________________________________
**Что происходит; кому и зачем нужно:**

HDMI не будет сразу запущен при загрузке системы
___________________________________
**Что поменялось для пользователей:**

На железе
___________________________________
**Как проверял/а:**
