### PR TITLE
rtl8733bu: move "c2h" warning log messages to debug level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb179) stable; urgency=medium
+
+  * rtl8733bu: move "c2h" warning log messages to debug level
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 24 Jul 2025 13:16:09 +0300
+
 linux-wb (5.10.35-wb178) stable; urgency=medium
 
   * rtl8733bu: move BusyTraffic log messages to debug level


### PR DESCRIPTION
Немного обновил драйвер RTL8733BU: https://github.com/wirenboard/rtl8733bu/pull/20