### PR TITLE
rtl8733bu: move "c2h" warning log messages to debug level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb141) stable; urgency=medium
+
+  * rtl8733bu: move "c2h" warning log messages to debug level
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 24 Jul 2025 13:14:02 +0300
+
 linux-wb (6.8.0-wb140) stable; urgency=medium
 
   * wb8: add netfilter modules


### PR DESCRIPTION
Немного обновил драйвер RTL8733BU: https://github.com/wirenboard/rtl8733bu/pull/20

