### PR TITLE
Revert "Disabled HDMI by default so that it could be enabled in overl…

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard851.dts
@@ -54,6 +54,15 @@
 
 };
 
+&de {
+	status = "okay";
+};
+
+&hdmi {
+	hvcc-supply = <&reg_aldo1>;
+	status = "okay";
+};
+
 &hdmi_out {
 	hdmi_out_con: endpoint {
 		remote-endpoint = <&hdmi_con_in>;

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
@@ -824,7 +824,6 @@
 			phys = <&hdmi_phy>;
 			phy-names = "phy";
 			status = "disabled";
-			hvcc-supply = <&reg_aldo1>;
 
 			ports {
 				#address-cells = <1>;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb143) stable; urgency=medium
+
+  * Revert "Disabled HDMI by default so that it could be enabled in overlays later"
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Fri, 15 Aug 2025 10:57:17 +0300
+
 linux-wb (6.8.0-wb142) stable; urgency=medium
 
   * wb8: Disabled HDMI by default so that it could be enabled in overlays later


### PR DESCRIPTION
Отменяем коммит 1a73f605ca9f1857e253240c970287616a1be784, возвращая статическое включение HDMI в базовой DTS. 

**Причина:** 
механизм runtime-оверлеев для HDMI в нашей конфигурации ведёт себя нестабильно и даёт предупреждения ядра; принято решение отказаться от оверлеев для HDMI и держать узлы включёнными постоянно.

**Мотивация / почему это нужно**

* При применении/снятии оверлеев через configfs наблюдались WARN’ы и проблемы с жизненным циклом объектов DT:
```bash
kobject: '(null)' ... kobject_put()
refcount_t: underflow; use-after-free
of_overlay_remove()/free_overlay_changeset
```
* Динамическое включение HDMI через overlay не даёт практических преимуществ для нашего случая, а увеличивает сложность и риск гонок/утечек.
* Статическая конфигурация DTS (узлы &de и &hdmi с status = "okay" и корректными supply-ссылками) работает предсказуемо и не затрагивает overlay-подсистему.