### PR TITLE
jenkinsfile: set customMainBranch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildWbKernel defaultTargets: 'wb8 wb8x-bootlet'
+buildWbKernel defaultTargets: 'wb8 wb8x-bootlet',
+              customMainBranch: 'dev/v6.8'


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
по мотивам https://github.com/wirenboard/jenkins-pipeline-lib/pull/135

___________________________________
**Что поменялось для пользователей:**
ничего, влияет только на формирование версии у вновь созданой ветки от dev/v6.8,
например:
`linux-image-wb8_6.8.0-wb147~exp~feature+jenkinsfile+customMainBranch+6+8~1~g57609b361215_arm64.deb`
вместо
`linux-image-wb8_6.8.0-wb147~exp~feature+jenkinsfile+customMainBranch+6+8~157~g57609b361215_arm64.deb`
___________________________________
**Как проверял/а:**
ci

