### PR TITLE
jenkinsfile: set customMainBranch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildWbKernel defaultTargets: 'wb6 wb7 wb6x-bootlet wb7x-bootlet wb7x-factory-bootlet'
+buildWbKernel defaultTargets: 'wb6 wb7 wb6x-bootlet wb7x-bootlet wb7x-factory-bootlet',
+              customMainBranch: 'dev/v5.10.y'


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
по мотивам https://github.com/wirenboard/jenkins-pipeline-lib/pull/135

___________________________________
**Что поменялось для пользователей:**
ничего, влияет только на формирование версии у вновь созданой ветки от dev/v5.10.y,
например:
`linux-image-wb7_5.10.35-wb180~exp~feature+jenkinsfile+customMainBranch+5+10~1~ge866efa87090_armhf.deb`
вместо
`linux-image-wb7_5.10.35-wb180~exp~feature+jenkinsfile+customMainBranch+5+10~451~ge866efa87090_armhf.deb`
___________________________________
**Как проверял/а:**
ci

