### PR TITLE
Features/soft 6125 hdmi 4 k 60fps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb148) stable; urgency=medium
+
+  * wb8.5 HDMI: reject >30Hz 4K modes on H616 since T507-H can’t drive 4K60 reliably
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Fri, 07 Nov 2025 12:22:36 +0300
+
 linux-wb (6.8.0-wb147) stable; urgency=medium
 
   * wb8.5 HDMI: enable HDMI audio

--- a/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
+++ b/drivers/gpu/drm/sun4i/sun8i_dw_hdmi.c
@@ -45,6 +45,12 @@ sun8i_dw_hdmi_mode_valid_h6(struct dw_hdmi *hdmi, void *data,
 			    const struct drm_display_info *info,
 			    const struct drm_display_mode *mode)
 {
+	unsigned int refresh = drm_mode_vrefresh(mode);
+
+	if (mode->hdisplay == 3840 && mode->vdisplay == 2160 &&
+	    refresh > 40)
+		return MODE_CLOCK_HIGH;
+
 	/*
 	 * Controller support maximum of 594 MHz, which correlates to
 	 * 4K@60Hz 4:4:4 or RGB.


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Так как наш T507-H (согласно даташиту) не поддерживает режимы HDMI 4K с фреймрейтом более 30fps, то ограничил возможность выбора этих фреймрейтов.

___________________________________
**Что поменялось для пользователей:**
Пользователь не сможет выбрать/установить неподдерживаемые фреймрейты

___________________________________
**Как проверял/а:**
На мониторе с поддержкой 4k 60fps команда `modetest -M sun4i-drm -a` больше не отображает фреймрейт >30fps для 4К
В веб-админке тоже не отображает и не дает установить неподдерживаемые режимы.


