### PR TITLE
Change axp20x capacity reading error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb150) stable; urgency=medium
+
+  * wb8: change error in case of axp20x capacity reading error
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 03 Feb 2026 16:09:38 +0300
+
 linux-wb (6.8.0-wb149) stable; urgency=medium
 
   * wb8.config: add prp hsr support

--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -307,7 +307,7 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 			return ret;
 
 		if (axp20x_batt->data->has_fg_valid && !(reg & AXP22X_FG_VALID))
-			return -EINVAL;
+			return -ENODATA;
 
 		/*
 		 * Fuel Gauge data takes 7 bits but the stored value seems to be


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Иногда чтение остаточного заряда батареи проходит неудачно (битик валидности данных приходит сброшенный). В оригинальном драйвере в этом случае возвращается EINVAL - Invalid argument, из за этого из udevadm прочитать никакие свойства нельзя (инвалидируется вобще весь девайс), юзеры не могут получить даже уровень напряжения. Поменяла ошибку на ENODATA - при ошибке чтения оно просто скипается и все остальное нормально доступно через udevadm
___________________________________
**Что поменялось для пользователей:**
Будет отображаться корректный уровень напряжения если даже чтение capacity прошло неудачно

___________________________________
**Как проверял/а:**

у себя на wb 8.4
