### PR TITLE
Feature/fw 812 add 7 bits word length to uart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb151) UNRELEASED; urgency=medium
+
+  * Added cs6 and cs7 to wbec_uart
+
+ -- HomePC <egor.panchenko@wirenboard.com>  Tue, 17 Feb 2026 16:30:20 +0300
+
 linux-wb (6.8.0-wb150) stable; urgency=medium
 
   * wb8: change error in case of axp20x capacity reading error

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 linux-wb (6.8.0-wb151) stable; urgency=medium
 
-  * Added cs6 and cs7 to wbec_uart
+  * Added CS7 to wbec_uart
 
  -- HomePC <egor.panchenko@wirenboard.com>  Tue, 17 Feb 2026 16:30:20 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-linux-wb (6.8.0-wb151) UNRELEASED; urgency=medium
+linux-wb (6.8.0-wb151) stable; urgency=medium
 
   * Added cs6 and cs7 to wbec_uart
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ linux-wb (6.8.0-wb151) stable; urgency=medium
 
   * Added CS7 to wbec_uart
 
- -- HomePC <egor.panchenko@wirenboard.com>  Tue, 17 Feb 2026 16:30:20 +0300
+ -- Egor Panchenko <egor.panchenko@wirenboard.com>  Tue, 17 Feb 2026 16:30:20 +0300
 
 linux-wb (6.8.0-wb150) stable; urgency=medium
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -105,7 +105,7 @@ struct uart_ctrl {
 	uint16_t stop_bits : 2;
 	uint16_t rs485_enabled : 1;
 	uint16_t rs485_rx_during_tx : 1;
-	uint16_t data_width : 2; // reserve 2 bits for 0/1 value for optional adding 6-,9-data bits modes in future
+	uint16_t data_width : 2; // reserve 2 bits for 0/1 value for optional adding 6-,9-data bits modes in future 
 	uint16_t res2 : 8;
 } __packed;
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -431,15 +431,12 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	// Supported in WBEC starting from firmware version 2.1.0.
 	// Older versions will ignore this setting and use 8 data bits.
 	switch (new->c_cflag & CSIZE) {
-	case CS6:
-		ctrl_regs.ctrl.data_width = 0; /* 6 data bits */
+	default:
+	case CS8:
+		ctrl_regs.ctrl.data_width = 0; /* 8 data bits (default) */
 		break;
 	case CS7:
 		ctrl_regs.ctrl.data_width = 1; /* 7 data bits */
-		break;
-	default:
-	case CS8:
-		ctrl_regs.ctrl.data_width = 2; /* 8 data bits (default) */
 		break;
 	}
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -36,6 +36,9 @@
 #define WBEC_UART_RX_BYTE_ERROR_NE		BIT(2)
 #define WBEC_UART_RX_BYTE_ERROR_ORE		BIT(3)
 
+#define WBEC_UART_MIN_BAUD_RATE 1200
+#define WBEC_UART_MAX_BAUD_RATE 115200
+
 struct wbec_uart_regmap_address {
 	u16 ctrl;
 	u16 tx_start;
@@ -432,6 +435,8 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	// Older versions will ignore this setting and use 8 data bits.
 	switch (new->c_cflag & CSIZE) {
 	default:
+		dev_err(port->dev, "Failed to set termios: CS value not applied, WBEC-UART supports only CS7 and CS8. 
+			The default value is set - CS8\n");
 	case CS8:
 		ctrl_regs.ctrl.data_width = 0; /* 8 data bits (default) */
 		break;
@@ -441,7 +446,15 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	}
 
 	/* Baud rate */
-	baud = uart_get_baud_rate(port, new, old, 1200, 115200);
+	speed_t requested_speed = tty_termios_baud_rate(new);
+	int baud = uart_get_baud_rate(port, new, old, WBEC_UART_MIN_BAUD_RATE, WBEC_UART_MAX_BAUD_RATE);
+	if (baud != requested_speed) {
+		// The values differ if the user attempts to set speed that out of range.
+		// In that case uart_get_baud_rate may return 9600 baud rate and we use
+		// tty_termios_baud_rate to avoid this case to be applyed without error message.
+		dev_err(port->dev, "Requested baudrate %d is out of supported range ["WBEC_UART_MIN_BAUD_RATE"-"WBEC_UART_MAX_BAUD_RATE"], set to default %d\n",
+				requested_speed, baud);
+	}
 	ctrl_regs.ctrl.baud_x100 = baud / 100;
 
 	regmap_bulk_write(regmap, ctrl_reg, ctrl_regs.buf, ARRAY_SIZE(ctrl_regs.buf));

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -436,7 +436,7 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	// Older versions will ignore this setting and use 8 data bits.
 	switch (new->c_cflag & CSIZE) {
 	default:
-		dev_err(port->dev, "Failed to set termios: CS value not applied, WBEC-UART supports only CS7 and CS8. 
+		dev_err(port->dev, "Failed to set termios: CS value not applied, WBEC-UART supports only CS7 and CS8. \
 			The default value is set - CS8\n");
 	case CS8:
 		ctrl_regs.ctrl.data_width = 0; /* 8 data bits (default) */

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -450,7 +450,7 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	speed_t requested_speed = tty_termios_baud_rate(new);
 	int baud = uart_get_baud_rate(port, new, old, WBEC_UART_MIN_BAUD_RATE, WBEC_UART_MAX_BAUD_RATE);
 	if (baud != requested_speed) {
-		// The values differ if the user attempts to set speed that out of range.
+		// The values differ if the user attempts to set a speed that is out of range.
 		// In that case uart_get_baud_rate may return 9600 baud rate and we use
 		// tty_termios_baud_rate to detect invalid speed and report an error.
 		dev_err(port->dev, "Requested baudrate %d is out of supported range [" __stringify(WBEC_UART_MIN_BAUD_RATE) "-"

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -429,15 +429,15 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 
 	/* Data width (character size) */
 	switch (new->c_cflag & CSIZE) {
-	case CS7:
-		ctrl_regs.ctrl.data_width = 0; /* 7 data bits */
+	case CS6:
+		ctrl_regs.ctrl.data_width = 0; /* 6 data bits */
 		break;
-	case CS9:
-		ctrl_regs.ctrl.data_width = 2; /* 9 data bits */
+	case CS7:
+		ctrl_regs.ctrl.data_width = 1; /* 7 data bits */
 		break;
 	default:
 	case CS8:
-		ctrl_regs.ctrl.data_width = 1; /* 8 data bits (default) */
+		ctrl_regs.ctrl.data_width = 2; /* 8 data bits (default) */
 		break;
 	}
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -24,6 +24,7 @@
 #include <linux/of.h>
 #include <linux/of_platform.h>
 #include <linux/device/bus.h>
+#include <linux/stringify.h>
 
 #define DRIVER_NAME				"wbec-uart"
 #define WBEC_UART_PORT_COUNT			2
@@ -451,9 +452,9 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	if (baud != requested_speed) {
 		// The values differ if the user attempts to set speed that out of range.
 		// In that case uart_get_baud_rate may return 9600 baud rate and we use
-		// tty_termios_baud_rate to avoid this case to be applyed without error message.
-		dev_err(port->dev, "Requested baudrate %d is out of supported range ["WBEC_UART_MIN_BAUD_RATE"-"WBEC_UART_MAX_BAUD_RATE"], set to default %d\n",
-				requested_speed, baud);
+		// tty_termios_baud_rate to detect invalid speed and report an error.
+		dev_err(port->dev, "Requested baudrate %d is out of supported range [" __stringify(WBEC_UART_MIN_BAUD_RATE) "-"
+			 __stringify(WBEC_UART_MAX_BAUD_RATE) "], set to default %d\n", requested_speed, baud);
 	}
 	ctrl_regs.ctrl.baud_x100 = baud / 100;
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -448,7 +448,7 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 
 	/* Baud rate */
 	speed_t requested_speed = tty_termios_baud_rate(new);
-	int baud = uart_get_baud_rate(port, new, old, WBEC_UART_MIN_BAUD_RATE, WBEC_UART_MAX_BAUD_RATE);
+	baud = uart_get_baud_rate(port, new, old, WBEC_UART_MIN_BAUD_RATE, WBEC_UART_MAX_BAUD_RATE);
 	if (baud != requested_speed) {
 		// The values differ if the user attempts to set a speed that is out of range.
 		// In that case uart_get_baud_rate may return 9600 baud rate and we use

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -437,7 +437,7 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 	switch (new->c_cflag & CSIZE) {
 	default:
 		dev_err(port->dev, "Failed to set termios: CS value not applied, WBEC-UART supports only CS7 and CS8. \
-			The default value is set - CS8\n");
+The default value is set - CS8\n");
 	case CS8:
 		ctrl_regs.ctrl.data_width = 0; /* 8 data bits (default) */
 		break;

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -105,7 +105,7 @@ struct uart_ctrl {
 	uint16_t stop_bits : 2;
 	uint16_t rs485_enabled : 1;
 	uint16_t rs485_rx_during_tx : 1;
-	uint16_t data_width : 2;
+	uint16_t data_width : 2; // reserve 2 bits for 0/1 value for optional adding 6-,9-data bits modes in future
 	uint16_t res2 : 8;
 } __packed;
 

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -428,6 +428,8 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 		ctrl_regs.ctrl.stop_bits = 0; /* 1 */
 
 	/* Data width (character size) */
+	// Supported in WBEC starting from firmware version 2.1.0.
+	// Older versions will ignore this setting and use 8 data bits.
 	switch (new->c_cflag & CSIZE) {
 	case CS6:
 		ctrl_regs.ctrl.data_width = 0; /* 6 data bits */

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -105,7 +105,8 @@ struct uart_ctrl {
 	uint16_t stop_bits : 2;
 	uint16_t rs485_enabled : 1;
 	uint16_t rs485_rx_during_tx : 1;
-	uint16_t res2 : 10;
+	uint16_t data_width : 2;
+	uint16_t res2 : 8;
 } __packed;
 
 union uart_ctrl_regs {
@@ -425,6 +426,20 @@ static void wbec_uart_set_termios(struct uart_port *port, struct ktermios *new,
 		ctrl_regs.ctrl.stop_bits = 2; /* 2 */
 	else
 		ctrl_regs.ctrl.stop_bits = 0; /* 1 */
+
+	/* Data width (character size) */
+	switch (new->c_cflag & CSIZE) {
+	case CS7:
+		ctrl_regs.ctrl.data_width = 0; /* 7 data bits */
+		break;
+	case CS9:
+		ctrl_regs.ctrl.data_width = 2; /* 9 data bits */
+		break;
+	default:
+	case CS8:
+		ctrl_regs.ctrl.data_width = 1; /* 8 data bits (default) */
+		break;
+	}
 
 	/* Baud rate */
 	baud = uart_get_baud_rate(port, new, old, 1200, 115200);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Необходимо научить wbec и его драйвер на linux работе uart в режиме 7e1.
[Связанный PR в wb-embedded-controller](https://github.com/wirenboard/wb-embedded-controller/pull/67)
___________________________________
**Что поменялось для пользователей:**
Появится возможность подключения через MOD1 и MOD2 на WB8.5 к счётчикам компании "Энергомера", которые требуют работы в режиме 7e1, это изначальная цель тикета. Но так же появляется возможность подключаться через MOD1 и MOD2 и к другим устройствам, которые требуют форматы 7n, 7e, 7o. Раньше через эти порты можно было общаться только в режимах 8n, 8e, 8o. 

___________________________________
**Как проверял/а:**
Вначале на столе разработчика, замкнув в петлю MOD1 на MOD2. Потом на стенде со счётчиками:
https://wirenboard.cloud/organizations/ebd1a3f3-5870-4572-8072-8261d94b334c/controllers/AOFJTE5
В 7-битном режиме общаются счётчики CE102M и CE301.
Так же проверил что не ломается совместимость с нашими модулями на стенде с парой WB M1W2 v.3 по одному на MOD1 и MOD2.:
https://wirenboard.cloud/organizations/ebd1a3f3-5870-4572-8072-8261d94b334c/controllers/AI34KN7B


