### PR TITLE
Feauture/4556 linux headers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (5.10.35-wb182) stable; urgency=medium
+
+  * wb7: scripts/package/wb/builddeb: fix linux-headers package contents
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Fri, 20 Mar 2026 15:24:28 +0300
+
 linux-wb (5.10.35-wb181) stable; urgency=medium
 
   *  wb7: add prp hsr as module

--- a/scripts/package/wb/builddeb
+++ b/scripts/package/wb/builddeb
@@ -87,6 +87,64 @@ set_debarch() {
 
 }
 
+build_target_headers_scripts() {
+	local destdir="$1"
+	local target_cc="${CC:-${CROSS_COMPILE}gcc}"
+	local common_cflags="-Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu11"
+
+	(
+		cd "$destdir"
+
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/basic \
+			-o scripts/basic/fixdep \
+			scripts/basic/fixdep.c
+
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/mod \
+			-c -o scripts/mod/modpost.o \
+			scripts/mod/modpost.c
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/mod \
+			-c -o scripts/mod/file2alias.o \
+			scripts/mod/file2alias.c
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/mod \
+			-c -o scripts/mod/sumversion.o \
+			scripts/mod/sumversion.c
+		"$target_cc" \
+			-o scripts/mod/modpost \
+			scripts/mod/modpost.o \
+			scripts/mod/file2alias.o \
+			scripts/mod/sumversion.o
+
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/genksyms \
+			-c -o scripts/genksyms/genksyms.o \
+			scripts/genksyms/genksyms.c
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/genksyms \
+			-c -o scripts/genksyms/parse.tab.o \
+			scripts/genksyms/parse.tab.c
+		"$target_cc" $common_cflags \
+			-I scripts/include \
+			-I scripts/genksyms \
+			-c -o scripts/genksyms/lex.lex.o \
+			scripts/genksyms/lex.lex.c
+		"$target_cc" \
+			-o scripts/genksyms/genksyms \
+			scripts/genksyms/genksyms.o \
+			scripts/genksyms/parse.tab.o \
+			scripts/genksyms/lex.lex.o
+	)
+}
+
 # Some variables and settings used throughout the script
 if [ -z "$KDEB_WBTARGET" ]; then
     echo "Please set KDEB_WBTARGET to build Wirenboard debian package" >&2
@@ -344,10 +402,13 @@ EOF
 fi
 
 # Build kernel header package
-(cd $srctree; find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl) > "$objtree/debian/hdrsrcfiles"
-(cd $srctree; find arch/*/include include scripts -type f) >> "$objtree/debian/hdrsrcfiles"
-(cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
-(cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
+(
+	cd $srctree
+	find . arch/$SRCARCH -maxdepth 1 -name Makefile\*
+	find include scripts -type f -o -type l
+	find arch/$SRCARCH -name Kbuild.platforms -o -name Platform
+	find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f
+) > "$objtree/debian/hdrsrcfiles"
 if grep -q '^CONFIG_STACK_VALIDATION=y' $KCONFIG_CONFIG ; then
 	(cd $objtree; find tools/objtool -type f -executable) >> "$objtree/debian/hdrobjfiles"
 fi
@@ -360,6 +421,7 @@ mkdir -p "$destdir"
 (cd $srctree; tar -c -f - -T -) < "$objtree/debian/hdrsrcfiles" | (cd $destdir; tar -xf -)
 (cd $objtree; tar -c -f - -T -) < "$objtree/debian/hdrobjfiles" | (cd $destdir; tar -xf -)
 (cd $objtree; cp $KCONFIG_CONFIG $destdir/.config) # copy .config manually to be where it's expected to be
+build_target_headers_scripts "$destdir"
 ln -sf "/usr/src/linux-headers-$version" "$kernel_headers_dir/lib/modules/$version/build"
 rm -f "$objtree/debian/hdrsrcfiles" "$objtree/debian/hdrobjfiles"
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Скрипты в linux-headers-wb* пакетах были собраны для неправильной архитектуры
Поправил для wb7

___________________________________
**Что поменялось для пользователей:**
Раньше было:
```
root@wirenboard-AEUZZCZ:~# file /usr/src/linux-headers-5.10.35-wb181/scripts/basic/fixdep
/usr/src/linux-headers-5.10.35-wb181/scripts/basic/fixdep: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=3924778d1c7b1f2d97ca55ce70584917752d6802, for GNU/Linux 3.2.0, not stripped
```

Стало:
```
root@wirenboard-AEUZZCZ:~# file /usr/src/linux-headers-5.10.35-wb180/scripts/basic/fixdep
/usr/src/linux-headers-5.10.35-wb180/scripts/basic/fixdep: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, BuildID[sha1]=7205ecccccbc5250589fa9f911f9eccee9db14b6, for GNU/Linux 3.2.0, not stripped
```


___________________________________
**Как проверял/а:**
Установкой deb-пакета с хидерами на wb7

