### PR TITLE
Feature/sdnand

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -1319,6 +1319,13 @@
 };
 
 &mmc2 {
+	/*
+	 * WB8.5.x may populate this soldered slot with either eMMC or SD NAND.
+	 * Keep the eMMC-capable controller profile and allow both media types:
+	 * the MMC core will probe SD first and then fall back to MMC.
+	 */
+	compatible = "allwinner,sun50i-h616-emmc",
+		     "allwinner,sun50i-a100-emmc";
 	vmmc-supply = <&reg_dcdc1>;
 	vqmmc-supply = <&reg_aldo1>;
 	bus-width = <8>;
@@ -1327,8 +1334,6 @@
 	mmc-hs200-1_8v;
 	mmc-hs400-1_8v;
 	no-sdio;
-	no-sd;
-	cap-mmc-highspeed;
 	status = "okay";
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb157) stable; urgency=medium
+
+  * wb8: dts: Add support for SDNAND
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Thu, 09 Apr 2026 20:39:35 +0300
+
 linux-wb (6.8.0-wb156) stable; urgency=medium
 
   * serial: wbec-uart: fix self-deadlock in remove() when tty is still open


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил поддержку SDNAND вместо EMMC

___________________________________
**Что поменялось для пользователей:**
Работает SDNAND, когда он впаян вместо EMMC

___________________________________
**Как проверял/а:**
на эксперементальном контроллере 8.5 с SDNAND
на обычном wb85 с EMMC

