### PR TITLE
Feature/sdnand bootlet

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8-bootlet.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard8-bootlet.dts
@@ -89,3 +89,16 @@
 		#pwm-cells = <3>;
 	};
 };
+
+&mmc2 {
+	/*
+     * Soldered internal slot may carry eMMC or SD NAND. Mirror the WB8.5
+     * (wirenboard85x) fix: let the MMC core probe SD first and fall back
+     * to eMMC. wirenboard84x.dtsi still ships the eMMC-only profile, so
+     * drop the SD-blocking properties here.
+     */
+    compatible = "allwinner,sun50i-h616-emmc",
+                 "allwinner,sun50i-a100-emmc";
+    /delete-property/ no-sd;
+    /delete-property/ cap-mmc-highspeed;
+};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-wb (6.8.0-wb159) stable; urgency=medium
+
+  * wb8: enable sdnand in bootlet
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 05 Jun 2026 16:57:33 +0300
+
 linux-wb (6.8.0-wb158) stable; urgency=medium
 
   * wb8.config: add ttl module


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
начал гонять прототипы с sdnand и выяснил, что загрузочная микросд (а также и бутлет) не умеют в sdnand => ничего не работает

___________________________________
**Что поменялось для пользователей:**
ничего; прототипы еще не вышли в производство

___________________________________
**Как проверял/а:**
погонял на вб с sdnand (бутлет и микро-ядро 38071cb той же кодовой базы); погонял на обычных вб (бутлет) - все ок, еммс видно

