### PR TITLE
wb8: persist panic logs across reboots (pstore/ramoops + warm reset support)

### DIFF
--- a/Documentation/devicetree/bindings/mfd/x-powers,axp152.yaml
+++ b/Documentation/devicetree/bindings/mfd/x-powers,axp152.yaml
@@ -67,6 +67,17 @@ allOf:
         properties:
           compatible:
             contains:
+              const: x-powers,axp15060
+
+    then:
+      properties:
+        x-powers,no-pwrok-restart: false
+
+  - if:
+      not:
+        properties:
+          compatible:
+            contains:
               enum:
                 - x-powers,axp15060
                 - x-powers,axp305
@@ -140,6 +151,15 @@ properties:
       Set this when the N_VBUSEN pin is used as an output pin to control an
       external regulator to drive the OTG VBus, rather then as an input pin
       which signals whether the board is driving OTG VBus or not.
+
+  x-powers,no-pwrok-restart:
+    type: boolean
+    description: >
+      Set this when the board relies on the PMIC ignoring an external low
+      pulse on the PWROK pin (for example when PWROK is wired as a reset
+      input to the SoC and an external supervisor pulses it to reset the
+      SoC while all PMIC outputs stay enabled). Clears the "restart on
+      PWROK drive low" function in case a bootloader enabled it.
 
   x-powers,self-working-mode:
     type: boolean

--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -1203,6 +1203,12 @@
 		#interrupt-cells = <1>;
 
 		wakeup-source;
+		/*
+		 * PWROK is wired to the T507 RESET pin; the EC pulses it to
+		 * warm-reset the SoC with DRAM (ramoops) preserved. The PMIC
+		 * must not restart on that pulse.
+		 */
+		x-powers,no-pwrok-restart;
 		overtemp_shutdown = <1>;
 		overtemp_value = <145>;
 

--- a/arch/arm64/configs/wb8.config
+++ b/arch/arm64/configs/wb8.config
@@ -160,13 +160,17 @@ CONFIG_WQ_CPU_INTENSIVE_REPORT=y
 CONFIG_TEST_LOCKUP=m
 
 # Persist kernel panic logs and console tail in DRAM across warm reboots
-# (pstore/ramoops; the region is defined in the board dts). DRAM survives
-# the warm reset (PWROK pulse) that the two-stage EC watchdog performs on
-# its first timeout. With panic timeout left at 0 a panicked kernel waits
-# for the EC watchdog to warm-reset the board, then systemd-pstore
+# (pstore/ramoops; U-Boot injects the reserved-memory region at the top
+# of the fitted DRAM, so one kernel works for any density). systemd-pstore
 # harvests /sys/fs/pstore on the next boot.
 CONFIG_PSTORE_RAM=y
 CONFIG_PSTORE_CONSOLE=y
+# On panic (timeout stays 0), the SoC watchdog arms and warm-resets 3 s
+# after the panic record has been written to ramoops - a SoC-only reset
+# that preserves DRAM. The two-stage EC watchdog remains the backstop:
+# warm PWROK reset for hangs and for panics where this never fires, hard
+# power cycle if the system does not come back.
+CONFIG_SUNXI_WATCHDOG_PANIC_TIMEOUT=3
 
 # Thermal interfaces
 CONFIG_THERMAL_NETLINK=y

--- a/arch/arm64/configs/wb8.config
+++ b/arch/arm64/configs/wb8.config
@@ -159,6 +159,15 @@ CONFIG_WQ_WATCHDOG=y
 CONFIG_WQ_CPU_INTENSIVE_REPORT=y
 CONFIG_TEST_LOCKUP=m
 
+# Persist kernel panic logs and console tail in DRAM across warm reboots
+# (pstore/ramoops; the region is defined in the board dts). DRAM survives
+# the warm reset (PWROK pulse) that the two-stage EC watchdog performs on
+# its first timeout. With panic timeout left at 0 a panicked kernel waits
+# for the EC watchdog to warm-reset the board, then systemd-pstore
+# harvests /sys/fs/pstore on the next boot.
+CONFIG_PSTORE_RAM=y
+CONFIG_PSTORE_CONSOLE=y
+
 # Thermal interfaces
 CONFIG_THERMAL_NETLINK=y
 CONFIG_THERMAL_STATISTICS=y

--- a/drivers/mfd/axp20x.c
+++ b/drivers/mfd/axp20x.c
@@ -33,6 +33,8 @@
 #define AXP806_REG_ADDR_EXT_ADDR_MASTER_MODE	0
 #define AXP806_REG_ADDR_EXT_ADDR_SLAVE_MODE	BIT(4)
 
+#define AXP15060_PWR_DIS_DOWN_PWROK_RESTART	BIT(4)
+
 static const char * const axp20x_model_names[] = {
 	[AXP152_ID] = "AXP152",
 	[AXP192_ID] = "AXP192",
@@ -1449,6 +1451,27 @@ int axp20x_device_probe(struct axp20x_dev *axp20x)
 		else
 			regmap_write(axp20x->regmap, AXP806_REG_ADDR_EXT,
 				     AXP806_REG_ADDR_EXT_ADDR_SLAVE_MODE);
+	}
+
+	/*
+	 * On some boards the PWROK pin is wired as a reset input to the SoC
+	 * and an external supervisor pulses it low to reset the SoC while
+	 * the PMIC keeps all outputs enabled, so that DRAM contents (e.g.
+	 * pstore/ramoops records) survive the reset. That only works with
+	 * the "restart the PMIC on external PWROK drive low" function
+	 * disabled. The function is disabled on power-on reset, but a
+	 * bootloader may have enabled it; disable it when the devicetree
+	 * says the board relies on PWROK being ignored by the PMIC.
+	 */
+	if (axp20x->variant == AXP15060_ID &&
+	    of_property_read_bool(axp20x->dev->of_node,
+				  "x-powers,no-pwrok-restart")) {
+		ret = regmap_clear_bits(axp20x->regmap,
+					AXP15060_PWR_DISABLE_DOWN_SEQ,
+					AXP15060_PWR_DIS_DOWN_PWROK_RESTART);
+		if (ret)
+			dev_warn(axp20x->dev,
+				 "failed to disable PWROK restart: %d\n", ret);
 	}
 
 	/* Only if there is an interrupt line connected towards the CPU. */

--- a/drivers/mfd/wbec.c
+++ b/drivers/mfd/wbec.c
@@ -25,6 +25,7 @@
 /* For power off WBEC activates PWON pin on PMIC for 6s */
 #define WBEC_POWER_RESET_DELAY_MS			10000
 
+/* Indices must match EC firmware linux_poweron_reason enum (regmap ABI) */
 static const char * const wbec_poweron_reason[] = {
 	"Power supply on",
 	"Power button",
@@ -33,6 +34,8 @@ static const char * const wbec_poweron_reason[] = {
 	"Reboot instead of poweroff",
 	"Watchdog",
 	"PMIC is unexpectedly off",
+	"Unknown",
+	"Watchdog (warm reset)",
 };
 
 static const struct regmap_config wbec_regmap_config_v1 = {

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -699,6 +699,20 @@ config SUNXI_WATCHDOG
 	  To compile this driver as a module, choose M here: the
 	  module will be called sunxi_wdt.
 
+config SUNXI_WATCHDOG_PANIC_TIMEOUT
+	int "Arm the watchdog on kernel panic (seconds, 0 to disable)"
+	depends on SUNXI_WATCHDOG
+	range 0 16
+	default 0
+	help
+	  If nonzero, a panic notifier arms the watchdog with the given
+	  timeout, so a panicked machine resets itself shortly after the
+	  panic has been logged (e.g. to pstore/ramoops) even when the
+	  panic timeout is 0. The watchdog performs a SoC-level reset
+	  that leaves DRAM contents intact, so ramoops records survive.
+	  Can be overridden at runtime via the sunxi_wdt.panic_timeout
+	  module parameter. If unsure, say 0.
+
 config NPCM7XX_WATCHDOG
 	tristate "Nuvoton NPCM750 watchdog"
 	depends on ARCH_NPCM || COMPILE_TEST

--- a/drivers/watchdog/sunxi_wdt.c
+++ b/drivers/watchdog/sunxi_wdt.c
@@ -18,6 +18,7 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/of.h>
+#include <linux/panic_notifier.h>
 #include <linux/platform_device.h>
 #include <linux/types.h>
 #include <linux/watchdog.h>
@@ -35,6 +36,7 @@
 
 static bool nowayout = WATCHDOG_NOWAYOUT;
 static unsigned int timeout;
+static unsigned int panic_wdt_timeout = CONFIG_SUNXI_WATCHDOG_PANIC_TIMEOUT;
 
 /*
  * This structure stores the register offsets for different variants
@@ -255,6 +257,69 @@ static const struct of_device_id sunxi_wdt_dt_ids[] = {
 };
 MODULE_DEVICE_TABLE(of, sunxi_wdt_dt_ids);
 
+/*
+ * Panic handling: when the panic_wdt_timeout module parameter is nonzero, arm
+ * the watchdog from a panic notifier so a panicked machine resets itself
+ * shortly after the panic, even with the kernel panic timeout set to 0.
+ *
+ * The notifier only ARMS the watchdog and returns: panic notifiers run
+ * before kmsg_dump(), so the panic record must still be written (e.g. to
+ * pstore/ramoops) before the reset fires. The watchdog resets the SoC
+ * without cutting power, leaving DRAM - and thus ramoops records - intact.
+ *
+ * All register accesses in the ops used here are plain MMIO with no
+ * locking, which is safe in panic context (secondary CPUs are stopped).
+ */
+static struct sunxi_wdt_dev *sunxi_wdt_panic_instance;
+
+static int sunxi_wdt_panic_notify(struct notifier_block *nb,
+				  unsigned long code, void *unused)
+{
+	struct sunxi_wdt_dev *sunxi_wdt = READ_ONCE(sunxi_wdt_panic_instance);
+	unsigned int t = READ_ONCE(panic_wdt_timeout);
+
+	if (!sunxi_wdt || !t)
+		return NOTIFY_DONE;
+
+	t = clamp(t, (unsigned int)WDT_MIN_TIMEOUT,
+		  (unsigned int)WDT_MAX_TIMEOUT);
+
+	pr_emerg("%s: arming watchdog, reset in %u s\n", DRV_NAME, t);
+
+	sunxi_wdt->wdt_dev.timeout = t;
+	sunxi_wdt_start(&sunxi_wdt->wdt_dev);
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block sunxi_wdt_panic_nb = {
+	.notifier_call = sunxi_wdt_panic_notify,
+	/* run early: arming a recovery watchdog must not be skipped
+	 * because another notifier crashed before us */
+	.priority = INT_MAX,
+};
+
+static void sunxi_wdt_unregister_panic_notifier(void *data)
+{
+	atomic_notifier_chain_unregister(&panic_notifier_list,
+					 &sunxi_wdt_panic_nb);
+	WRITE_ONCE(sunxi_wdt_panic_instance, NULL);
+}
+
+static int sunxi_wdt_register_panic_notifier(struct device *dev,
+					     struct sunxi_wdt_dev *sunxi_wdt)
+{
+	if (cmpxchg(&sunxi_wdt_panic_instance, NULL, sunxi_wdt))
+		return 0;	/* already owned by another instance */
+
+	atomic_notifier_chain_register(&panic_notifier_list,
+				       &sunxi_wdt_panic_nb);
+
+	return devm_add_action_or_reset(dev,
+					sunxi_wdt_unregister_panic_notifier,
+					NULL);
+}
+
 static int sunxi_wdt_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
@@ -293,6 +358,10 @@ static int sunxi_wdt_probe(struct platform_device *pdev)
 	if (unlikely(err))
 		return err;
 
+	err = sunxi_wdt_register_panic_notifier(dev, sunxi_wdt);
+	if (err)
+		return err;
+
 	dev_info(dev, "Watchdog enabled (timeout=%d sec, nowayout=%d)",
 		 sunxi_wdt->wdt_dev.timeout, nowayout);
 
@@ -311,6 +380,10 @@ module_platform_driver(sunxi_wdt_driver);
 
 module_param(timeout, uint, 0);
 MODULE_PARM_DESC(timeout, "Watchdog heartbeat in seconds");
+
+module_param(panic_wdt_timeout, uint, 0644);
+MODULE_PARM_DESC(panic_wdt_timeout, "Arm watchdog on kernel panic with this timeout in seconds (default="
+		 __MODULE_STRING(CONFIG_SUNXI_WATCHDOG_PANIC_TIMEOUT) ", 0 to disable)");
 
 module_param(nowayout, bool, 0);
 MODULE_PARM_DESC(nowayout, "Watchdog cannot be stopped once started "


### PR DESCRIPTION
**What changed**

- `wb8`: enable pstore/ramoops (`CONFIG_PSTORE_RAM` + `CONFIG_PSTORE_CONSOLE`). Panic logs and the console tail persist in a DRAM region across warm reboots; systemd-pstore harvests them on the next boot. The reserved-memory region is injected by U-Boot at the top of the fitted DRAM (companion U-Boot PR: wirenboard/u-boot-private#83), so one kernel works for any DRAM density. Also adds the missing "Unknown" and the new "Watchdog (warm reset)" poweron reason strings (companion EC firmware PR: wirenboard/wb-embedded-controller#90).
- `mfd: axp20x`: new DT property `x-powers,no-pwrok-restart` — clears AXP15060 reg 0x32 bit 4 at probe so an external PWROK pulse (the EC warm reset) resets only the SoC while all PMIC rails, including DRAM power, stay up. Set for WB 8.5x. Intended for upstream (split into dt-bindings/driver/dts + S-o-b when submitting).
- `watchdog: sunxi_wdt`: opt-in panic notifier (`panic_wdt_timeout` module param / `SUNXI_WATCHDOG_PANIC_TIMEOUT` Kconfig default, ipmi_watchdog precedent) that arms the watchdog on panic, after which the panic record is written to ramoops and the SoC warm-resets. wb8.config sets 3 s: panic recovery drops from the EC watchdog timeout (up to 60 s parked) to ~3 s.

**Why**

Preserve kernel panic/hang logs across reboots on WB8. The EC watchdog power-cycles the SoC on hang, wiping DRAM; the warm-reset chain (EC PWROK pulse / SoC watchdog) keeps DRAM alive so ramoops records survive.

**Test plan**

On a WB 8.5.1 bench unit (EC fw 2.4.0 with the two-stage watchdog):
- DRAM retention across SoC-watchdog and EC-PWROK resets validated with a 16 MiB pattern — bit-perfect, zero ECC corrections in ramoops.
- End-to-end: `sysrq-c` panic → SoC watchdog warm reset at +3 s → boot, records harvested to journal/files → (userspace policy) one cold reboot → back at SSH in 71 s total. Repeated across multiple panic cycles, incl. hang-path recovery via the EC watchdog.
- Panic record verified to contain the full backtrace and the notifier's own "arming watchdog" line.

**Risks**

- Without the companion U-Boot fixup, no ramoops region exists and pstore is silently inactive (safe no-op on stock bootloaders).
- `panic_wdt_timeout` default is 0 (off) for non-WB kernels; WB opts in via wb8.config.
- Consumers detecting watchdog resets by poweron reason must treat both 5 and 8 as watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Companion PRs: wirenboard/wb-embedded-controller#90 (EC firmware), wirenboard/wb-diag-collect#66 (diag archive), wirenboard/u-boot-private#83 (ramoops region injection).
