### PR TITLE
serial: wbec-uart: fix xmit races with tty flush and shutdown

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+linux-wb (6.8.0-wb160) stable; urgency=medium
+
+  * wbec-uart: fix xmit races between SPI exchange and tty flush/shutdown:
+    NULL deref that killed the EC IRQ thread and left ttyMOD1/2 dead with
+    unkillable D-state processes until reboot, and tail advance into a
+    flushed buffer that resurrected up to 4 KB of stale data onto the bus
+    and delayed port close by 10 s
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Tue, 07 Jul 2026 17:32:01 +0300
+
 linux-wb (6.8.0-wb159) stable; urgency=medium
 
   * wb8: enable sdnand in bootlet

--- a/drivers/tty/serial/wbec-uart.c
+++ b/drivers/tty/serial/wbec-uart.c
@@ -65,6 +65,16 @@ struct wbec_uart_one_port {
 	struct work_struct start_tx_work;
 	struct completion tx_complete;
 	struct regmap *regmap;
+	/*
+	 * Set on tty flush, cleared when xmit is sampled for an exchange;
+	 * both under the port lock. Exchanges are serialized (one threaded
+	 * IRQ caller under wbec_uart_mutex), so at most one sample epoch is
+	 * in flight and a bool is enough to tell whether a flush landed
+	 * between sampling xmit and accounting the exchange result:
+	 * advancing the tail of a flushed buffer would move it past the
+	 * head and resurrect up to UART_XMIT_SIZE of stale data as pending.
+	 */
+	bool xmit_flushed;
 };
 
 static struct wbec_uart_one_port *wbec_uart_ports[WBEC_UART_PORT_COUNT] = {};
@@ -145,16 +155,23 @@ static void swap_bytes(u16 *buf, int len)
 static void wbec_collect_data_for_exchange(struct wbec_uart_one_port *wbec_one_port, struct uart_tx *tx)
 {
 	struct uart_port *port = &wbec_one_port->port;
-	struct circ_buf *xmit;
+	struct circ_buf *xmit = &port->state->xmit;
+	unsigned long flags;
 
-	if (port == NULL) {
-		tx->bytes_to_send_count = 0;
-		return;
-	}
+	uart_port_lock_irqsave(port, &flags);
 
-	xmit = &port->state->xmit;
+	wbec_one_port->xmit_flushed = false;
 
-	if (uart_circ_empty(xmit) || uart_tx_stopped(port)) {
+	/*
+	 * On shutdown the serial core frees the xmit buffer and sets
+	 * xmit->buf to NULL under the port lock without clearing head/tail.
+	 * The close path can reach it with data still pending and no flush
+	 * (e.g. uart_wait_until_sent() timed out or was interrupted by a
+	 * signal), so a NULL buf may look non-empty. Sample the buffer only
+	 * under the port lock and treat a NULL buf as "nothing to send", as
+	 * uart_write() does.
+	 */
+	if (!xmit->buf || uart_circ_empty(xmit) || uart_tx_stopped(port)) {
 		tx->bytes_to_send_count = 0;
 	} else {
 		int i;
@@ -174,6 +191,8 @@ static void wbec_collect_data_for_exchange(struct wbec_uart_one_port *wbec_one_p
 		if (to_send)
 			reinit_completion(&wbec_one_port->tx_complete);
 	}
+
+	uart_port_unlock_irqrestore(port, flags);
 }
 
 static void wbec_process_received_exchange(struct wbec_uart_one_port *wbec_one_port,
@@ -227,12 +246,19 @@ static void wbec_process_received_exchange(struct wbec_uart_one_port *wbec_one_p
 	if (rx->ready_for_tx) {
 		unsigned long flags;
 
-		if (bytes_sent_in_exchange > 0)
-			uart_xmit_advance(port, bytes_sent_in_exchange);
-
 		uart_port_lock_irqsave(port, &flags);
-		if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
-			uart_write_wakeup(port);
+		/*
+		 * Skip the accounting if the buffer was freed by a concurrent
+		 * shutdown or flushed since the data for this exchange was
+		 * sampled: the sampled bytes no longer exist in the buffer.
+		 */
+		if (xmit->buf && !wbec_one_port->xmit_flushed) {
+			if (bytes_sent_in_exchange > 0)
+				uart_xmit_advance(port, bytes_sent_in_exchange);
+
+			if (uart_circ_chars_pending(xmit) < WAKEUP_CHARS)
+				uart_write_wakeup(port);
+		}
 		uart_port_unlock_irqrestore(port, flags);
 	}
 
@@ -311,6 +337,20 @@ static void wbec_start_tx_work_handler(struct work_struct *work)
 	regmap_write(regmap, wbec_uart_regmap_address[port->line].tx_start, 0x1);
 }
 
+
+static void wbec_uart_flush_buffer(struct uart_port *port)
+{
+	struct wbec_uart_one_port *p = container_of(port,
+					      struct wbec_uart_one_port,
+					      port);
+
+	/*
+	 * Called under the port lock right after uart_circ_clear().
+	 * Invalidate the bytes sampled for an in-flight SPI exchange, see
+	 * wbec_process_received_exchange().
+	 */
+	p->xmit_flushed = true;
+}
 
 static unsigned int wbec_uart_tx_empty(struct uart_port *port)
 {
@@ -533,6 +573,7 @@ static const struct uart_ops wbec_uart_ops = {
 	.break_ctl	= wbec_uart_break_ctl,
 	.startup	= wbec_uart_startup,
 	.shutdown	= wbec_uart_shutdown,
+	.flush_buffer	= wbec_uart_flush_buffer,
 	.set_termios	= wbec_uart_set_termios,
 	.type		= wbec_uart_type,
 	.request_port	= wbec_uart_request_port,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Баг у клиента kernel oops на WB 8.5.1 (6.8.0-wb159, AM3DT4LX) вскрыл **две** гонки в wbec-uart — обе от работы с `port->state->xmit` без port-лока:

1. **NULL deref / смерть ttyMOD1+2 до ребута.** `uart_shutdown()` освобождает `xmit.buf` под port-локом, которого exchange не брал; IRQ-поток разыменовывает NULL, умирает с захваченным `wbec_uart_mutex` → все последующие open/close ttyWBE* виснут в неубиваемом D-state, wb-mqtt-serial копится зомби-инстансами, зомби создают коллизии на здоровых портах.
2. **Воскрешение сброшенного буфера.** `uart_xmit_advance()` двигал хвост по результату exchange, сэмплированного за ~2.4 мс до того; flush (tcflush/close/hangup), попавший в это окно, приводил к `tail > head` — до 4 КБ уже удалённых данных (старые Modbus-кадры!) повторно уходили в шину, а закрытие порта ждало полный 10-секундный таймаут `tx_complete`. Доказано на проводе: сосед принимал 1205 байт вместо 64.

Фикс: выборка из `xmit` под `uart_port_lock` с проверкой `!xmit->buf` (контракт `uart_write()`); учёт результата exchange — под тем же локом и только если между сэмплированием и результатом не было flush (флаг в новом колбэке `uart_ops.flush_buffer`, который serial core зовёт под локом сразу после `uart_circ_clear()`; обмены сериализованы под `wbec_uart_mutex`, так что одного флага на эпоху сэмплирования достаточно). Попутно убрана мёртвая проверка `port == NULL`.

Актуально для всех WB8, где заняты **оба** MOD-порта и порты переоткрываются/флашатся (wb-mqtt-serial делает tcflush штатно).

Подробный разбор и отчёт об экспериментах (включая реабилитацию прошивки EC — механизм `tx_completed` работает корректно): https://claude.ai/code/artifact/4d721fc4-2848-4b06-b363-1421f0629fc5

⚠️ Ветка дважды переписана force-push'ем до начала ревью на GitHub: первая версия фикса закрывала только гонку 1; вторая правка — по итогам внутреннего ревью (исправлена атрибуция в комментарии: непустой head/tail при NULL buf даёт close-путь, hangup в этом дереве делает flush; счётчик поколений упрощён до bool-флага; порядок в ops-таблице).

___________________________________
**Что поменялось для пользователей:**

Ядро 6.8.0-wb160: kernel oops с потерей ttyMOD1/ttyMOD2 до перезагрузки не воспроизводится; после tcflush/закрытия порта в шину больше не уходят устаревшие данные; закрытие порта занимает честное время дренажа вместо фиксированных 10 секунд. Производительность портов не меняется.

___________________________________
**Как проверял/а:**

Стенд wb851 (WB 8.5.1): нуль-модем MOD1↔MOD3, MOD2↔MOD4, слоты в `wbe2x-generic-uart`.

- Баг воспроизведен (флуд на соседний порт + open@1200/write 4095/`TIOCVHANGUP`, задержки 2–30 мс): сток wb159 падает за ~30 с с полевой сигнатурой (`+0x110`, `x7=0`); с фиксом — 65+ итераций суммарно (MOD1 и MOD2) без падения, IRQ-поток жив.
- Гонка 2, замер на проводе (приёмник на MOD3, сверка содержимого): mid-burst hangup до фикса — 10.0 с и 1205 байт фантомного потока; после — 0.5 с и ровно 64 байта (принятый EC чанк). Чистый случай (без обмена в полёте) не изменился: 4.2 с / 512 байт — честный дренаж. Время закрытия масштабируется лесенкой по объёму переданного EC (0.5→3.2 с), без 10-секундных таймаутов.
- Калибровка честности `tx_complete` через `TIOCGICOUNT.tx`: задержка закрытия побайтово совпадает с временем дренажа принятых EC байт — completion-механизм прошивки работает точно.
- Голый `tcflush(TCOFLUSH)` посреди burst'а на открытом порту (пост-фикс): утекло 64 байта — ровно принятый EC чанк (до фикса поток продолжался бы до полного «воскрешённого» буфера), последующая запись доехала до соседа целой — порт работает штатно.
- Регрессия: целостность md5 (оба порта одновременно, обе стороны, 64К@115200 и 16К@9600) — 8/8; дренаж при обычном close() — 2000/2000 за 2.1 с (= времени дренажа); 50 циклов open/close со встречным трафиком — 0 ошибок; dmesg чист.
- Сборка: `defconfig + wb8.config`, gcc 13.3 aarch64, W=1 — новых предупреждений нет; checkpatch — 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
