### PR TITLE
wb7: fix USB gadget high-speed enumeration (PHY TX tune)

### DIFF
--- a/Documentation/devicetree/bindings/phy/allwinner,sun8i-r40-usb-phy.yaml
+++ b/Documentation/devicetree/bindings/phy/allwinner,sun8i-r40-usb-phy.yaml
@@ -98,6 +98,25 @@ properties:
   wirenboard,mux-on-id-pin:
     description: On Wiren Board 7 USB0 is muxed between USB-A connector for host mode and USB-C connector for peripheral mode. The mux is controller by voltage on perihperal connector. The same signal is used as USB ID.
 
+patternProperties:
+  "^allwinner,usb[0-2]-tx-amplitude$":
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 3
+    default: 0
+    description:
+      TX amplitude tune value for the given PHY. The default (0, the
+      minimum) may result in a high-speed TX signal too weak for some
+      link partners to receive.
+
+  "^allwinner,usb[0-2]-tx-slew-rate$":
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 7
+    default: 5
+    description:
+      TX slew rate tune value for the given PHY.
+
 required:
   - "#phy-cells"
   - compatible

--- a/arch/arm/boot/dts/allwinner/sun8i-r40-wirenboard72x.dtsi
+++ b/arch/arm/boot/dts/allwinner/sun8i-r40-wirenboard72x.dtsi
@@ -706,6 +706,12 @@
 	dr_mode = "otg";
 	wirenboard,mux-on-id-pin;
 
+	/* Maximum TX amplitude and slew rate: with the default TX tuning
+	 * (minimum amplitude) some hosts fail to receive high-speed data
+	 * from us: gadget enumeration fails and bulk data gets corrupted */
+	allwinner,usb0-tx-amplitude = <3>;
+	allwinner,usb0-tx-slew-rate = <7>;
+
 	status = "okay";
 };
 
@@ -980,7 +986,7 @@
 &usb_otg {
 	dr_mode = "peripheral";
 	status = "okay";
-	maximum-speed = "full-speed";
+	maximum-speed = "high-speed";
 };
 
 /* CPU RTC is useless since it doesn't have separate power supply. However we must keep it on to get proper LOSC for the rest of SoC.*/

--- a/arch/arm/boot/dts/allwinner/sun8i-r40-wirenboard74x.dtsi
+++ b/arch/arm/boot/dts/allwinner/sun8i-r40-wirenboard74x.dtsi
@@ -837,6 +837,12 @@
 	dr_mode = "otg";
 	wirenboard,mux-on-id-pin;
 
+	/* Maximum TX amplitude and slew rate: with the default TX tuning
+	 * (minimum amplitude) some hosts fail to receive high-speed data
+	 * from us: gadget enumeration fails and bulk data gets corrupted */
+	allwinner,usb0-tx-amplitude = <3>;
+	allwinner,usb0-tx-slew-rate = <7>;
+
 	status = "okay";
 };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.18.22-wb7) stable; urgency=medium
+
+  * phy-sun4i-usb: allow tuning PHY TX amplitude/slew rate via DT;
+    set both to maximum on Wiren Board 7 USB0: fixes high-speed gadget
+    enumeration failures and bulk data corruption on some hosts
+
+ -- Evgeny Boger <boger@wirenboard.com>  Fri, 10 Jul 2026 03:24:30 +0300
+
 linux-wb (6.18.22-wb6) stable; urgency=medium
 
   * scripts: fix wb6x-bootlet build

--- a/drivers/phy/allwinner/phy-sun4i-usb.c
+++ b/drivers/phy/allwinner/phy-sun4i-usb.c
@@ -12,6 +12,7 @@
  * Author: Sylwester Nawrocki <s.nawrocki@samsung.com>
  */
 
+#include <linux/bitfield.h>
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/err.h>
@@ -78,6 +79,17 @@
 #define PHY_DISCON_TH_SEL		0x2a
 #define PHY_SQUELCH_DETECT		0x3c
 
+/*
+ * TX tune field layout, written as 5 bits starting at
+ * PHY_TX_AMPLITUDE_TUNE. The default is inherited from the
+ * Allwinner BSP: amplitude 0 (minimum), slew rate 5.
+ */
+#define PHY_TX_AMPLITUDE_MASK		GENMASK(1, 0)
+#define PHY_TX_AMPLITUDE_MAX		3
+#define PHY_TX_SLEWRATE_MASK		GENMASK(4, 2)
+#define PHY_TX_SLEWRATE_MAX		7
+#define PHY_TX_TUNE_DEFAULT		0x14
+
 /* A83T specific control bits for PHY0 */
 #define PHY_CTL_VBUSVLDEXT		BIT(5)
 #define PHY_CTL_SIDDQ			BIT(3)
@@ -127,6 +139,7 @@ struct sun4i_usb_phy_data {
 		struct clk *clk2;
 		bool regulator_on;
 		int index;
+		u32 tx_tune;
 	} phys[MAX_PHYS];
 	/* phy0 / otg related variables */
 	struct extcon_dev *extcon;
@@ -394,7 +407,7 @@ static int sun4i_usb_phy_init(struct phy *_phy)
 			sun4i_usb_phy_write(phy, PHY_RES45_CAL_EN, 0x01, 1);
 
 		/* Adjust PHY's magnitude and rate */
-		sun4i_usb_phy_write(phy, PHY_TX_AMPLITUDE_TUNE, 0x14, 5);
+		sun4i_usb_phy_write(phy, PHY_TX_AMPLITUDE_TUNE, phy->tx_tune, 5);
 
 		/* Disconnect threshold adjustment */
 		sun4i_usb_phy_write(phy, PHY_DISCON_TH_SEL,
@@ -915,6 +928,7 @@ static int sun4i_usb_phy_probe(struct platform_device *pdev)
 	for (i = 0; i < MAX_PHYS; i++) {
 		struct sun4i_usb_phy *phy = data->phys + i;
 		char name[32];
+		u32 val;
 
 		if (data->cfg->missing_phys & BIT(i))
 			continue;
@@ -926,6 +940,30 @@ static int sun4i_usb_phy_probe(struct platform_device *pdev)
 				break;
 			dev_err(dev, "failed to get reset %s\n", name);
 			return PTR_ERR(phy->reset);
+		}
+
+		phy->tx_tune = PHY_TX_TUNE_DEFAULT;
+
+		snprintf(name, sizeof(name), "allwinner,usb%d-tx-amplitude", i);
+		if (!of_property_read_u32(np, name, &val)) {
+			if (val > PHY_TX_AMPLITUDE_MAX) {
+				dev_warn(dev, "%s out of range, clamping to %d\n",
+					 name, PHY_TX_AMPLITUDE_MAX);
+				val = PHY_TX_AMPLITUDE_MAX;
+			}
+			phy->tx_tune &= ~PHY_TX_AMPLITUDE_MASK;
+			phy->tx_tune |= FIELD_PREP(PHY_TX_AMPLITUDE_MASK, val);
+		}
+
+		snprintf(name, sizeof(name), "allwinner,usb%d-tx-slew-rate", i);
+		if (!of_property_read_u32(np, name, &val)) {
+			if (val > PHY_TX_SLEWRATE_MAX) {
+				dev_warn(dev, "%s out of range, clamping to %d\n",
+					 name, PHY_TX_SLEWRATE_MAX);
+				val = PHY_TX_SLEWRATE_MAX;
+			}
+			phy->tx_tune &= ~PHY_TX_SLEWRATE_MASK;
+			phy->tx_tune |= FIELD_PREP(PHY_TX_SLEWRATE_MASK, val);
 		}
 
 		snprintf(name, sizeof(name), "usb%d_vbus", i);


### PR DESCRIPTION
## Problem

WB7 USB gadget reliably fails to enumerate at **high speed** when connected directly to some laptop root ports (no hub in between). The HS chirp handshake succeeds and host SETUP packets are decoded fine, but the host never accepts the ep0 IN data stage, so enumeration retries forever while musb floods dmesg with `SetupEnd came in a wrong ep0stage`. Through most hubs enumeration works, masking the issue.

This is the same marginality that #122 worked around by capping the gadget to full-speed — a cap that silently became a no-op on 6.x kernels (the 5.10-era `usb_get_maximum_speed()` parsing in musb sunxi glue was lost in the rebase), which is why the failure resurfaced.

## Root cause

`phy-sun4i-usb` hardcodes the PHY TX tune field (regs 0x20-0x24) to the Allwinner BSP default `0x14` = **minimum TX amplitude**, slew rate 5. The resulting HS TX signal is too weak for some host receivers.

## Fix

- new optional per-PHY DT properties `allwinner,usbX-tx-amplitude` (0-3) and `allwinner,usbX-tx-slew-rate` (0-7), defaults unchanged
- WB7 dts sets both to maximum for USB0

First two commits are upstream-shaped (bindings + driver), prepared for mainline submission as well.

## Validation (WB 7.4.2, ALEPBSP3, direct connection to Latitude 9430 root port)

Deterministic A/B on live hardware via PHY tp-write:

| tune value | enumeration | iperf host-side rx_errors per 10 s run |
|---|---|---|
| 0x14 (stock: amp 0, slew 5) | **fails** (state=default forever) | n/a |
| 0x15 / 0x16 (amp 1-2) | fails | n/a |
| 0x17 (amp 3, slew 5) | OK | 1231 |
| 0x1b (amp 3, slew 6) | OK | 112 |
| **0x1f (amp 3, slew 7)** | **OK, 4/4 cycles** | **4; then 0 over 60 s saturated duplex** |

Kernel built from this branch (6.18.22-wb6-usbtune, device config) — boots pending on-device deb verification.

## Caveats

- Tune values validated against a handful of hosts and via-hub paths on the bench; broader fleet/host coverage welcome before undrafting.
- The `maximum-speed = "high-speed"` dts change is currently unparsed (see above) and only documents intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)