### PR TITLE
arm64: dts: allwinner: wirenboard85x: park CPU at a boot-safe OPP across suspend

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-wirenboard85x.dtsi
@@ -1662,3 +1662,20 @@
 &iommu {
 	status = "okay";
 };
+
+/*
+ * Suspend-to-off contract with the boot firmware: on resume, U-Boot
+ * SPL's board init runs before the resume branch and programs VDD-CPU
+ * to its 0.90 V cold-boot value (CONFIG_AXP_DCDC2_VOLT), and BL31 then
+ * restores the PLL frequency the kernel parked at. The OPP the kernel
+ * parks at across suspend must therefore be safe at 0.90 V on every
+ * speed bin. 480 MHz is 0.90 V-rated and bin-universal
+ * (opp-supported-hw 0x1f). The primary fix lives in BL31 (it restores
+ * the recorded voltage before the recorded frequency); this is the
+ * kernel-side belt in case firmware and kernel ever skew.
+ */
+&cpu_opp_table {
+	opp-480000000 {
+		opp-suspend;
+	};
+};


### PR DESCRIPTION
Kernel-side belt for the WB8.5 suspend-to-off resume voltage contract: SPL programs VDD-CPU to 0.90 V on the resume path while BL31 restores the kernel-parked PLL frequency (up to 1416 MHz). Parking at the bin-universal 0.90 V-rated 480 MHz OPP across suspend (`opp-suspend`) keeps the resume window safe even if firmware and kernel versions skew. The primary fix is firmware-side (wirenboard/arm-trusted-firmware#4, restores the recorded voltage before the recorded frequency) — this PR is standalone and safe with or without it. Verified: `sun50i-h616-wirenboard851.dtb` builds and carries the property (fdtget-checked).

Root-cause evidence: 10 corruption samples (fetch faults on valid code, single-bit pointer flips, CPU-bringup lockups, always <2 s post-resume, DRAM CRC clean every time), root-caused and eliminated on the bench 2026-07-10 (210+ clean cycles since).

🤖 Generated with [Claude Code](https://claude.com/claude-code)