### PR TITLE
pinctrl: sunxi: keep a shadow copy of the data register output latches (v6.18)

### DIFF
--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
@@ -1622,6 +1622,16 @@ int sunxi_pinctrl_init_with_flags(struct platform_device *pdev,
 		return -ENOMEM;
 
 	/*
+	 * The bus clock has to be enabled before any register access, which
+	 * happens as soon as the shadow is seeded below, and later on from
+	 * the pin hogs applied when the pinctrl device registers.
+	 */
+	ret = of_clk_get_parent_count(node);
+	clk = devm_clk_get_enabled(&pdev->dev, ret == 1 ? NULL : "apb");
+	if (IS_ERR(clk))
+		return PTR_ERR(clk);
+
+	/*
 	 * Seed the output latch shadow from the hardware so pins the
 	 * bootloader left in output mode keep their state; see
 	 * sunxi_pinctrl_gpio_set() for why a shadow is needed.  This must
@@ -1728,13 +1738,6 @@ int sunxi_pinctrl_init_with_flags(struct platform_device *pdev,
 					     pin->pin.number, 1);
 		if (ret)
 			goto gpiochip_error;
-	}
-
-	ret = of_clk_get_parent_count(node);
-	clk = devm_clk_get_enabled(&pdev->dev, ret == 1 ? NULL : "apb");
-	if (IS_ERR(clk)) {
-		ret = PTR_ERR(clk);
-		goto gpiochip_error;
 	}
 
 	pctl->irq = devm_kcalloc(&pdev->dev,

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
@@ -808,6 +808,21 @@ static void sunxi_pmx_set(struct pinctrl_dev *pctldev,
 	writel((readl(pctl->membase + reg) & ~mask) | config << shift,
 	       pctl->membase + reg);
 
+	/*
+	 * A pin muxed to gpio_out directly through a pinmux node bypasses
+	 * sunxi_pinctrl_gpio_set() and drives whatever its output latch
+	 * holds.  Now that the pin is in output mode the data register
+	 * reads back the latch, so refresh the shadow to keep such pins
+	 * driving their pre-existing level.
+	 */
+	if (config == SUN4I_FUNC_OUTPUT) {
+		u32 *shadow = &pctl->dat_shadow[pin / PINS_PER_BANK];
+
+		sunxi_data_reg(pctl, pin, &reg, &shift, &mask);
+		*shadow = (*shadow & ~mask) |
+			  (readl(pctl->membase + reg) & mask);
+	}
+
 	raw_spin_unlock_irqrestore(&pctl->lock, flags);
 }
 
@@ -1020,21 +1035,29 @@ static int sunxi_pinctrl_gpio_set(struct gpio_chip *chip, unsigned int offset,
 				  int value)
 {
 	struct sunxi_pinctrl *pctl = gpiochip_get_data(chip);
-	u32 reg, shift, mask, val;
+	u32 *shadow = &pctl->dat_shadow[offset / PINS_PER_BANK];
+	u32 reg, shift, mask;
 	unsigned long flags;
 
 	sunxi_data_reg(pctl, offset, &reg, &shift, &mask);
 
 	raw_spin_lock_irqsave(&pctl->lock, flags);
 
-	val = readl(pctl->membase + reg);
-
+	/*
+	 * Reading the data register returns the pin level, not the output
+	 * latch, for pins muxed as inputs.  A read-modify-write based on
+	 * the register would therefore corrupt the latches of input-muxed
+	 * pins in the same bank (e.g. an emulated open-drain I2C line
+	 * released high), making them drive the wrong level once switched
+	 * to output.  Base the read-modify-write on a shadow copy of the
+	 * latches instead.
+	 */
 	if (value)
-		val |= mask;
+		*shadow |= mask;
 	else
-		val &= ~mask;
+		*shadow &= ~mask;
 
-	writel(val, pctl->membase + reg);
+	writel(*shadow, pctl->membase + reg);
 
 	raw_spin_unlock_irqrestore(&pctl->lock, flags);
 
@@ -1560,7 +1583,7 @@ int sunxi_pinctrl_init_with_flags(struct platform_device *pdev,
 	struct pinctrl_pin_desc *pins;
 	struct sunxi_pinctrl *pctl;
 	struct pinmux_ops *pmxops;
-	int i, ret, last_pin, pin_idx;
+	int i, ret, last_pin, pin_idx, nbanks;
 	struct clk *clk;
 
 	pctl = devm_kzalloc(&pdev->dev, sizeof(*pctl), GFP_KERNEL);
@@ -1597,6 +1620,28 @@ int sunxi_pinctrl_init_with_flags(struct platform_device *pdev,
 				       GFP_KERNEL);
 	if (!pctl->irq_array)
 		return -ENOMEM;
+
+	/*
+	 * Seed the output latch shadow from the hardware so pins the
+	 * bootloader left in output mode keep their state; see
+	 * sunxi_pinctrl_gpio_set() for why a shadow is needed.  This must
+	 * happen before the pinctrl device registers, as pin hogs can mux
+	 * pins to gpio_out and thereby update the shadow.
+	 */
+	last_pin = pctl->desc->pins[pctl->desc->npins - 1].pin.number;
+	nbanks = (round_up(last_pin, PINS_PER_BANK) - pctl->desc->pin_base) /
+		 PINS_PER_BANK;
+	pctl->dat_shadow = devm_kcalloc(&pdev->dev, nbanks,
+					sizeof(*pctl->dat_shadow), GFP_KERNEL);
+	if (!pctl->dat_shadow)
+		return -ENOMEM;
+
+	for (i = 0; i < nbanks; i++) {
+		u32 reg, shift, mask;
+
+		sunxi_data_reg(pctl, i * PINS_PER_BANK, &reg, &shift, &mask);
+		pctl->dat_shadow[i] = readl(pctl->membase + reg);
+	}
 
 	ret = sunxi_pinctrl_build_state(pdev);
 	if (ret) {
@@ -1652,7 +1697,6 @@ int sunxi_pinctrl_init_with_flags(struct platform_device *pdev,
 	if (!pctl->chip)
 		return -ENOMEM;
 
-	last_pin = pctl->desc->pins[pctl->desc->npins - 1].pin.number;
 	pctl->chip->owner = THIS_MODULE;
 	pctl->chip->request = gpiochip_generic_request;
 	pctl->chip->free = gpiochip_generic_free;

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.h
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.h
@@ -174,6 +174,12 @@ struct sunxi_pinctrl {
 	int				*irq;
 	unsigned			*irq_array;
 	raw_spinlock_t			lock;
+	/*
+	 * Output latch shadow, one word per bank.  Seeded lockless at
+	 * probe before the pinctrl device registers, protected by @lock
+	 * afterwards.
+	 */
+	u32				*dat_shadow;
 	struct pinctrl_dev		*pctl_dev;
 	unsigned long			variant;
 	u32				bank_mem_size;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

На Allwinner чтение регистра данных банка GPIO возвращает уровень пина, а не выходную защёлку, для пинов в режиме входа. Поэтому read-modify-write в `sunxi_pinctrl_gpio_set()` портит защёлки всех соседних по банку пинов-входов: обратно записывается считанный уровень пина.

Ломает эмулируемый open-drain (i2c-gpio): отпущенная в high линия (вход + подтяжка) получает 1 в защёлку от любой конкурентной записи GPIO в том же банке, и при следующем переводе в low через неатомарную последовательность data→mux в `sunxi_pinctrl_gpio_direction_output()` пин может активно выдать push-pull high вместо low. Наблюдалось на WB 8.5.1 (T507): спорадические выбросы SCL/SDA в high на битбанг-шине ATECC/RTC (порт E) при переключении других PE-GPIO (A1 OUT, W2 UP и т.п.).

Исправление: теневая копия защёлок по банкам (по образцу gpio-mmio), RMW ведётся по тени, регистр только пишется. Тень сеется из железа на probe; пины, замуксенные в gpio_out напрямую через pinmux, обновляют свой бит тени в `sunxi_pmx_set()`.

Патч предназначен для отправки в mainline (Fixes: df7b34f4c3d2, Cc: stable).

___________________________________
**Что поменялось для пользователей:**

Исчезают спорадические глитчи на программных (bitbang) I2C-шинах и вообще любых эмулируемых open-drain линиях на sunxi при активности других GPIO того же банка. Прочее поведение GPIO не меняется.

___________________________________
**Как проверял/а:**

- `scripts/checkpatch.pl` на итоговом патче: 0 errors, 0 warnings (обе ветки).
- Полная сборка wb8-конфига (defconfig + wb8.config, aarch64) на обеих ветках — успешно.
- Ядро 6.18 с патчем установлено и загружено на WB 8.5.1 (T507, wirenboard-AADU6HJN): шина i2c_atecc_rtc работает (ATECC на 0x60 отвечает), 200×2 проб при параллельном «hammer»-тесте (быстрое переключение W2 UP в том же банке E) без деградации; регрессий в systemd-сервисах нет.
- Прогнан multi-aspect code review (стабильность/регрессии/безопасность и др.); найденный кейс «pinmux напрямую в gpio_out мимо gpiolib» закрыт синхронизацией тени в `sunxi_pmx_set()`.
