### PR TITLE
pinctrl: sunxi: keep a shadow copy of the data register output latches (v6.8)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb161) stable; urgency=medium
+
+  * pinctrl-sunxi: fix output latch corruption on GPIO writes: a write to
+    one GPIO poisoned the latches of input-muxed pins in the same bank,
+    causing sporadic glitches on bit-banged I2C buses
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Wed, 12 Aug 2026 15:23:15 +0300
+
 linux-wb (6.8.0-wb160) stable; urgency=medium
 
   * wbec-uart: fix xmit races between SPI exchange and tty flush/shutdown:

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
@@ -1539,6 +1539,16 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 		return -ENOMEM;
 
 	/*
+	 * The bus clock has to be enabled before any register access, which
+	 * happens as soon as the shadow is seeded below, and later on from
+	 * the pin hogs applied when the pinctrl device registers.
+	 */
+	ret = of_clk_get_parent_count(node);
+	clk = devm_clk_get_enabled(&pdev->dev, ret == 1 ? NULL : "apb");
+	if (IS_ERR(clk))
+		return PTR_ERR(clk);
+
+	/*
 	 * Seed the output latch shadow from the hardware so pins the
 	 * bootloader left in output mode keep their state; see
 	 * sunxi_pinctrl_gpio_set() for why a shadow is needed.  This must
@@ -1646,31 +1656,20 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 			goto gpiochip_error;
 	}
 
-	ret = of_clk_get_parent_count(node);
-	clk = devm_clk_get(&pdev->dev, ret == 1 ? NULL : "apb");
-	if (IS_ERR(clk)) {
-		ret = PTR_ERR(clk);
-		goto gpiochip_error;
-	}
-
-	ret = clk_prepare_enable(clk);
-	if (ret)
-		goto gpiochip_error;
-
 	pctl->irq = devm_kcalloc(&pdev->dev,
 				 pctl->desc->irq_banks,
 				 sizeof(*pctl->irq),
 				 GFP_KERNEL);
 	if (!pctl->irq) {
 		ret = -ENOMEM;
-		goto clk_error;
+		goto gpiochip_error;
 	}
 
 	for (i = 0; i < pctl->desc->irq_banks; i++) {
 		pctl->irq[i] = platform_get_irq(pdev, i);
 		if (pctl->irq[i] < 0) {
 			ret = pctl->irq[i];
-			goto clk_error;
+			goto gpiochip_error;
 		}
 	}
 
@@ -1681,7 +1680,7 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 	if (!pctl->domain) {
 		dev_err(&pdev->dev, "Couldn't register IRQ domain\n");
 		ret = -ENOMEM;
-		goto clk_error;
+		goto gpiochip_error;
 	}
 
 	for (i = 0; i < (pctl->desc->irq_banks * IRQ_PER_BANK); i++) {
@@ -1713,8 +1712,6 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 
 	return 0;
 
-clk_error:
-	clk_disable_unprepare(clk);
 gpiochip_error:
 	gpiochip_remove(pctl->chip);
 	return ret;

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
@@ -787,6 +787,21 @@ static void sunxi_pmx_set(struct pinctrl_dev *pctldev,
 	writel((readl(pctl->membase + reg) & ~mask) | config << shift,
 	       pctl->membase + reg);
 
+	/*
+	 * A pin muxed to gpio_out directly through a pinmux node bypasses
+	 * sunxi_pinctrl_gpio_set() and drives whatever its output latch
+	 * holds.  Now that the pin is in output mode the data register
+	 * reads back the latch, so refresh the shadow to keep such pins
+	 * driving their pre-existing level.
+	 */
+	if (config == SUN4I_FUNC_OUTPUT) {
+		u32 *shadow = &pctl->dat_shadow[pin / PINS_PER_BANK];
+
+		sunxi_data_reg(pctl, pin, &reg, &shift, &mask);
+		*shadow = (*shadow & ~mask) |
+			  (readl(pctl->membase + reg) & mask);
+	}
+
 	raw_spin_unlock_irqrestore(&pctl->lock, flags);
 }
 
@@ -943,21 +958,29 @@ static void sunxi_pinctrl_gpio_set(struct gpio_chip *chip,
 				unsigned offset, int value)
 {
 	struct sunxi_pinctrl *pctl = gpiochip_get_data(chip);
-	u32 reg, shift, mask, val;
+	u32 *shadow = &pctl->dat_shadow[offset / PINS_PER_BANK];
+	u32 reg, shift, mask;
 	unsigned long flags;
 
 	sunxi_data_reg(pctl, offset, &reg, &shift, &mask);
 
 	raw_spin_lock_irqsave(&pctl->lock, flags);
 
-	val = readl(pctl->membase + reg);
-
+	/*
+	 * Reading the data register returns the pin level, not the output
+	 * latch, for pins muxed as inputs.  A read-modify-write based on
+	 * the register would therefore corrupt the latches of input-muxed
+	 * pins in the same bank (e.g. an emulated open-drain I2C line
+	 * released high), making them drive the wrong level once switched
+	 * to output.  Base the read-modify-write on a shadow copy of the
+	 * latches instead.
+	 */
 	if (value)
-		val |= mask;
+		*shadow |= mask;
 	else
-		val &= ~mask;
+		*shadow &= ~mask;
 
-	writel(val, pctl->membase + reg);
+	writel(*shadow, pctl->membase + reg);
 
 	raw_spin_unlock_irqrestore(&pctl->lock, flags);
 }
@@ -1481,7 +1504,7 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 	struct pinctrl_pin_desc *pins;
 	struct sunxi_pinctrl *pctl;
 	struct pinmux_ops *pmxops;
-	int i, ret, last_pin, pin_idx;
+	int i, ret, last_pin, pin_idx, nbanks;
 	struct clk *clk;
 
 	pctl = devm_kzalloc(&pdev->dev, sizeof(*pctl), GFP_KERNEL);
@@ -1514,6 +1537,28 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 				       GFP_KERNEL);
 	if (!pctl->irq_array)
 		return -ENOMEM;
+
+	/*
+	 * Seed the output latch shadow from the hardware so pins the
+	 * bootloader left in output mode keep their state; see
+	 * sunxi_pinctrl_gpio_set() for why a shadow is needed.  This must
+	 * happen before the pinctrl device registers, as pin hogs can mux
+	 * pins to gpio_out and thereby update the shadow.
+	 */
+	last_pin = pctl->desc->pins[pctl->desc->npins - 1].pin.number;
+	nbanks = (round_up(last_pin, PINS_PER_BANK) - pctl->desc->pin_base) /
+		 PINS_PER_BANK;
+	pctl->dat_shadow = devm_kcalloc(&pdev->dev, nbanks,
+					sizeof(*pctl->dat_shadow), GFP_KERNEL);
+	if (!pctl->dat_shadow)
+		return -ENOMEM;
+
+	for (i = 0; i < nbanks; i++) {
+		u32 reg, shift, mask;
+
+		sunxi_data_reg(pctl, i * PINS_PER_BANK, &reg, &shift, &mask);
+		pctl->dat_shadow[i] = readl(pctl->membase + reg);
+	}
 
 	ret = sunxi_pinctrl_build_state(pdev);
 	if (ret) {
@@ -1569,7 +1614,6 @@ int sunxi_pinctrl_init_with_variant(struct platform_device *pdev,
 	if (!pctl->chip)
 		return -ENOMEM;
 
-	last_pin = pctl->desc->pins[pctl->desc->npins - 1].pin.number;
 	pctl->chip->owner = THIS_MODULE;
 	pctl->chip->request = gpiochip_generic_request;
 	pctl->chip->free = gpiochip_generic_free;

--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.h
+++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.h
@@ -80,6 +80,7 @@
 #define IO_BIAS_MASK		GENMASK(3, 0)
 
 #define SUN4I_FUNC_INPUT	0
+#define SUN4I_FUNC_OUTPUT	1
 #define SUN4I_FUNC_IRQ		6
 
 #define PINCTRL_SUN5I_A10S	BIT(1)
@@ -173,6 +174,12 @@ struct sunxi_pinctrl {
 	int				*irq;
 	unsigned			*irq_array;
 	raw_spinlock_t			lock;
+	/*
+	 * Output latch shadow, one word per bank.  Seeded lockless at
+	 * probe before the pinctrl device registers, protected by @lock
+	 * afterwards.
+	 */
+	u32				*dat_shadow;
 	struct pinctrl_dev		*pctl_dev;
 	unsigned long			variant;
 	u32				bank_mem_size;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

На Allwinner чтение регистра данных банка GPIO возвращает уровень пина, а не выходную защёлку, для пинов в режиме входа. Поэтому read-modify-write в `sunxi_pinctrl_gpio_set()` портит защёлки всех соседних по банку пинов-входов: обратно записывается считанный уровень пина.

Ломает эмулируемый open-drain (i2c-gpio): отпущенная в high линия (вход + подтяжка) получает 1 в защёлку от любой конкурентной записи GPIO в том же банке, и при следующем переводе в low через неатомарную последовательность data→mux в `sunxi_pinctrl_gpio_direction_output()` пин может активно выдать push-pull high вместо low. Наблюдалось на WB 8.5.1 (T507): спорадические выбросы SCL/SDA в high на битбанг-шине ATECC/RTC (порт E) при переключении других PE-GPIO (A1 OUT, W2 UP и т.п.).

Исправление: теневая копия защёлок по банкам (по образцу gpio-mmio), RMW ведётся по тени, регистр только пишется. Тень сеется из железа на probe; пины, замуксенные в gpio_out напрямую через pinmux, обновляют свой бит тени в `sunxi_pmx_set()`.

Патч предназначен для отправки в mainline (Fixes: df7b34f4c3d2, Cc: stable).

___________________________________
**Что поменялось для пользователей:**

Исчезают спорадические глитчи на программных (bitbang) I2C-шинах и вообще любых эмулируемых open-drain линиях на sunxi при активности других GPIO того же банка. Прочее поведение GPIO не меняется.

___________________________________
**Как проверял/а:**

- `scripts/checkpatch.pl` на итоговом патче: 0 errors, 0 warnings (обе ветки).
- Полная сборка wb8-конфига (defconfig + wb8.config, aarch64) на обеих ветках — успешно.
- Ядро 6.18 с патчем установлено и загружено на WB 8.5.1 (T507, wirenboard-AADU6HJN): шина i2c_atecc_rtc работает (ATECC на 0x60 отвечает), 200×2 проб при параллельном «hammer»-тесте (быстрое переключение W2 UP в том же банке E) без деградации; регрессий в systemd-сервисах нет.
- Прогнан multi-aspect code review (стабильность/регрессии/безопасность и др.); найденный кейс «pinmux напрямую в gpio_out мимо gpiolib» закрыт синхронизацией тени в `sunxi_pmx_set()`.
