### PR TITLE
Jenkinsfile: build wb8x-bootlet with online-demokit initramfs by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 buildWbKernel defaultTargets: 'wb8 wb8x-bootlet',
-              customMainBranch: 'dev/v6.8'
+              customMainBranch: 'dev/v6.8',
+              defaultWbInitramfsBranch: 'permanent/online-demokit'


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Bootlet для демочемодана (`wb8x-bootlet`) должен собираться с demokit-initramfs из `wirenboard/wb-initramfs`, ветка `permanent/online-demokit` (write-protect + восстановление разметки). Раньше это делалось вручную: job запускали с `INITRAMFS_URLS=http://fw-releases.wirenboard.com/utils/initramfs.deb`, куда заранее заливали собранный deb (видно в логе сборки #3 ветки).

`buildWbKernel` умеет брать initramfs напрямую из артефактов job'а wb-initramfs по имени ветки (`WB_INITRAMFS_BRANCH` → `copyArtifacts`). Задаём это значением по умолчанию в Jenkinsfile demokit-ветки, чтобы автоматическая сборка ветки давала правильный bootlet без ручных параметров.

___________________________________
**Что поменялось для пользователей:**

Сборка `permanent/wb8-online-demokit` по умолчанию тянет `wb-initramfs-wb8x` из `wb-initramfs/permanent/online-demokit` (последний успешный билд), а не из dev-tools. На другие ветки не влияет.

___________________________________
**Как проверял/а:**

Логика `WB_INITRAMFS_BRANCH` в `jenkins-pipeline-lib/vars/buildWbKernel.groovy`; job `wb-initramfs/permanent/online-demokit` собран успешно, артефакты в `pkgs/*.deb`. Сборка ядра по PR покажет версию initramfs в логе (`Initramfs version: …`).
