### PR TITLE
usb: gadget: composite: report bcdUSB 0x0210 when WebUSB is enabled (v6.8)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb162) stable; urgency=medium
+
+  * usb: gadget: composite: report bcdUSB 0x0210 when WebUSB is enabled,
+    so that Chromium reads the WebUSB landing page and shows the
+    plug-in notification for the Debug Network gadget
+
+ -- Evgeny Boger <boger@wirenboard.com>  Mon, 31 Aug 2026 17:04:48 +0300
+
 linux-wb (6.8.0-wb161) stable; urgency=medium
 
   * pinctrl-sunxi: fix output latch corruption on GPIO writes: a write to

--- a/drivers/usb/gadget/composite.c
+++ b/drivers/usb/gadget/composite.c
@@ -1838,7 +1838,13 @@ composite_setup(struct usb_gadget *gadget, const struct usb_ctrlrequest *ctrl)
 					cdev->desc.bcdUSB = cpu_to_le16(0x0210);
 				}
 			} else {
-				if (gadget->lpm_capable || cdev->use_webusb)
+				/*
+				 * WebUSB requires bcdUSB >= 2.10; Chromium does not
+				 * read the landing page from a device below that.
+				 */
+				if (cdev->use_webusb)
+					cdev->desc.bcdUSB = cpu_to_le16(0x0210);
+				else if (gadget->lpm_capable)
 					cdev->desc.bcdUSB = cpu_to_le16(0x0201);
 				else
 					cdev->desc.bcdUSB = cpu_to_le16(0x0200);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Ядро умеет отдавать WebUSB landing page для USB-гаджета (configfs `webusb/{use,bVendorCode,landingPage}`): в BOS-дескриптор добавляется WebUSB platform capability, а на vendor-запрос GET_URL возвращается URL. Chromium на десктопе по этому URL показывает уведомление «Go to \<site\> to connect \<device\>» при подключении устройства — хотим использовать это для Debug Network на WB8 (landing page → `https://10-200-200-1.<sn>.ip.wirenboard.com/`, т.е. веб-интерфейс контроллера).

Но `composite_setup()` для не-superspeed гаджета с `use_webusb` выдаёт `bcdUSB = 0x0201` (общая ветка с LPM), игнорируя значение из configfs. Спецификация WebUSB требует bcdUSB ≥ 2.10, и Chromium это проверяет жёстко: landing page читается только при версии ≥ 2.1.0 (`kUsbVersion2_1 = 0x0210` в `usb_service_linux.cc` и `usb_device_win.cc`). В итоге configfs-фича ядра для Chromium бесполезна: `chrome://usb-internals` показывает «USB Version: 2.0.1» и без landing page.

Патч отдаёт `0x0210` при `use_webusb`, для чисто LPM-случая оставляет `0x0201`. То же самое в mainline (master) — стоит отправить туда (Fixes: 93c473948c58).

___________________________________
**Что поменялось для пользователей:**

Само по себе ничего: `webusb/use` в configfs сейчас никто не включает. Когда wb-utils начнёт включать WebUSB для Debug Network (при настроенном HTTPS), в Chrome/Edge на Windows и Linux при подключении контроллера по USB появится уведомление со ссылкой на его веб-интерфейс. Для остального софта bcdUSB 2.10 вместо 2.01 — оба значения означают «USB 2.0 + BOS».

___________________________________
**Как проверял/а:**

- `scripts/checkpatch.pl` на патче: 0 errors, 0 warnings.
- Собран `libcomposite.ko` для 6.8.0-wb161 (кросс-сборка, vermagic совпадает), загружен на WB 8.5 (wirenboard-ALFLOJF3, musb HS). До патча хост видит bcdUSB 2.01, Chromium 144 на Linux — «USB Version: 2.0.1», landing page нет. После — bcdUSB 2.10, в `chrome://usb-internals` «USB Version: 2.1.0» и «WebUSB Landing Page: …», уведомление показывается, клик открывает веб-интерфейс по HTTPS.
- Полной сборки ядра не делал — изменение одной ветки в `composite_setup()`.
