### PR TITLE
usb: gadget: composite: report bcdUSB 0x0210 when WebUSB is enabled (v6.8)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb162) stable; urgency=medium
+
+  * usb: gadget: composite: report bcdUSB 0x0210 when WebUSB is enabled,
+    so that Chromium reads the WebUSB landing page and shows the
+    plug-in notification for the Debug Network gadget
+
+ -- Evgeny Boger <boger@wirenboard.com>  Mon, 31 Aug 2026 17:04:48 +0300
+
 linux-wb (6.8.0-wb161) stable; urgency=medium
 
   * pinctrl-sunxi: fix output latch corruption on GPIO writes: a write to

--- a/drivers/usb/gadget/composite.c
+++ b/drivers/usb/gadget/composite.c
@@ -1838,7 +1838,13 @@ composite_setup(struct usb_gadget *gadget, const struct usb_ctrlrequest *ctrl)
 					cdev->desc.bcdUSB = cpu_to_le16(0x0210);
 				}
 			} else {
-				if (gadget->lpm_capable || cdev->use_webusb)
+				/*
+				 * WebUSB requires bcdUSB >= 2.10; Chromium does not
+				 * read the landing page from a device below that.
+				 */
+				if (cdev->use_webusb)
+					cdev->desc.bcdUSB = cpu_to_le16(0x0210);
+				else if (gadget->lpm_capable)
 					cdev->desc.bcdUSB = cpu_to_le16(0x0201);
 				else
 					cdev->desc.bcdUSB = cpu_to_le16(0x0200);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Ядро умеет отдавать WebUSB landing page для USB-гаджета (configfs `webusb/{use,bVendorCode,landingPage}`, ядро ≥ 6.3): в BOS-дескриптор добавляется WebUSB platform capability, а на vendor-запрос GET_URL возвращается URL. Chromium на десктопе показывает по этому URL уведомление «Go to \<site\> to connect \<device\>» при подключении устройства.

Но `composite_setup()` для не-superspeed гаджета с `use_webusb` выдаёт `bcdUSB = 0x0201` (общая ветка с LPM), игнорируя значение из configfs. Спецификация WebUSB требует bcdUSB ≥ 2.10, и Chromium это проверяет жёстко: landing page читается только при версии ≥ 2.1.0 (`kUsbVersion2_1 = 0x0210` в `usb_service_linux.cc` и `usb_device_win.cc`). То есть configfs-фича ядра в связке с Chromium не работает вообще: `chrome://usb-internals` показывает «USB Version: 2.0.1» и landing page отсутствует.

Патч отдаёт `0x0210` при `use_webusb`, для чисто LPM-случая оставляет `0x0201`. Предназначен и для mainline (Fixes: 93c473948c58, Cc: stable).

___________________________________
**Что поменялось для пользователей:**

Прямо сейчас — ничего: `webusb/use` в configfs никто не включает, и при `use_webusb = 0` дескриптор прежний (bcdUSB 2.00, BOS не отдаётся) — проверено.

Дальше это нужно для Debug Network: планируется, что wb-utils будет включать WebUSB с landing page `https://10-200-200-1.<sn>.ip.wirenboard.com/` (веб-интерфейс контроллера), когда в wb-mqtt-homeui настроен HTTPS. Важно: одного этого патча для появления уведомления не хватит — Chromium на Linux не читает дескрипторы у устройств с mass-storage интерфейсом (`ShouldReadDescriptors()`), а на Windows отправляет GET_URL только через интерфейс, привязанный к драйверу WinUSB, которого у связки RNDIS+MSC нет. Это решается на стороне гаджета отдельно; данный патч — необходимое, но не достаточное условие.

___________________________________
**Как проверял/а:**

- `scripts/checkpatch.pl` (mainline-версия, знает тег `Assisted-by:`): 0 warnings; остаётся только `ERROR: Missing Signed-off-by` — по Documentation/process/coding-assistants.rst тег DCO ставит человек, см. ниже.
- Собран `libcomposite.ko` для 6.8.0-wb161 (кросс-сборка, vermagic совпадает), загружен на WB 8.5 (wirenboard-ALFLOJF3, musb HS):
  - `use_webusb = 1`: до патча хост видит bcdUSB 2.01, Chromium 144 — «USB Version: 2.0.1», landing page нет; после патча bcdUSB 2.10, `chrome://usb-internals` показывает «USB Version: 2.1.0» и «WebUSB Landing Page: …», уведомление появляется, клик открывает веб-интерфейс по HTTPS без предупреждения о сертификате.
  - `use_webusb = 0` (штатное состояние, HTTPS не настроен): bcdUSB 2.00, BOS не отдаётся, RNDIS и mass storage работают как раньше.
- Полной сборки ядра не делал — изменение одной ветки в `composite_setup()`.
- Не проверял: привязку RNDIS на «чистом» Windows-хосте при включённом WebUSB (Windows начнёт запрашивать BOS; ожидается штатный откат на MS OS 1.0 строку 0xEE, но это стоит проверить до включения WebUSB в wb-utils).

___________________________________
**AI-assisted:**

Патч и changelog подготовлены с помощью LLM-ассистента (тег `Assisted-by: LLM` по Documentation/process/coding-assistants.rst). По той же инструкции ассистент **не** ставит `Signed-off-by` — его добавляет человек-отправитель, подтверждая DCO.
