### PR TITLE
arm64: wb8.config: enable USB_GADGET_DEBUG_FILES for the RNDIS state file

### DIFF
--- a/arch/arm64/configs/wb8.config
+++ b/arch/arm64/configs/wb8.config
@@ -33,6 +33,9 @@ CONFIG_IIO_RESCALE=y
 # USB gadget support (Debug network)
 CONFIG_USB_ETH=m
 CONFIG_USB_GADGETFS=m
+# RNDIS handshake state in /proc/driver/rndis-NNN: wb-usb-otg reads it to tell a host
+# with an RNDIS driver (Windows, Linux) from one without it (macOS -> CDC ECM)
+CONFIG_USB_GADGET_DEBUG_FILES=y
 
 # Godex printer support
 CONFIG_USB_PRINTER=m

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+linux-wb (6.8.0-wb164) stable; urgency=medium
+
+  * arm64: wb8.config: enable USB_GADGET_DEBUG_FILES so the RNDIS gadget
+    function exposes its handshake state in /proc/driver/rndis-NNN; wb-utils
+    reads it to tell an RNDIS host from one that needs CDC ECM (macOS)
+
+ -- Evgeny Boger <boger@wirenboard.com>  Sat, 05 Sep 2026 21:51:53 +0300
+
 linux-wb (6.8.0-wb163) stable; urgency=medium
 
   * usb: gadget: configfs: add MS OS 2.0 descriptors support, without which


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Включает `CONFIG_USB_GADGET_DEBUG_FILES=y` в оверлее `wb8.config`. С этой опцией функция RNDIS гаджета показывает своё состояние в `/proc/driver/rndis-NNN` (`RNDIS_UNINITIALIZED` → `RNDIS_INITIALIZED` после `RNDIS_MSG_INIT` от хоста → `RNDIS_DATA_INITIALIZED` после установки packet filter).

Это нужно wb-utils (ветка `feature/debug-network-host-adaptive`), чтобы Debug Network работал на macOS: у macOS нет драйвера RNDIS, у Windows нет драйвера CDC ECM, а обе функции разом в одну конфигурацию не влезают (4+4 endpoint у musb H616) и вторая USB-конфигурация ломает usbccgp в Windows. Поэтому гаджет перечисляется как RNDIS, а демон смотрит, дошёл ли хост до RNDIS-рукопожатия; если за 4 с не дошёл, переперечисляется как CDC ECM. Файл в `/proc` даёт признак рукопожатия без ожидания пакетов, что важно для хостов с выключенными DHCP и IPv6. Carrier сетевого интерфейса для этого не годится: `gether_connect()` поднимает его при выборе интерфейса, до `RNDIS_MSG_INIT`.

Кроме `rndis-NNN` опция добавляет `/proc/driver/udc` с диагностикой контроллера; всё только на чтение. Исходники ядра не меняются. Стек: поверх #369 (версия wb164).

___________________________________
**Что поменялось для пользователей:**

Ничего заметного: появляется пара read-only файлов в `/proc/driver`. Без новой версии wb-utils они никем не читаются; wb-utils без этого файла продолжает работать по старому признаку (пакеты от хоста).

___________________________________
**Как проверял/а:**

- На WB 8.5 (wirenboard-ALFLOJF3, 6.8.0-wb161) пересобран только `usb_f_rndis.ko` с этой опцией из тега v6.8.0-wb161, без правок исходников, и установлен как override в `/lib/modules/.../updates/`. После реальной перезагрузки модуль загрузился сам, `/proc/driver/rndis-000` появился, демон wb-utils увидел `RNDIS_DATA_INITIALIZED` через 0.3 с после подключения Linux-хоста; сеть и диск работают.
- Замер на Win11 VM с новыми instance ID и удалённым кэшем usbflags: `RNDIS_INITIALIZED` через 1.1–1.3 с после SET_CONFIGURATION, при повторном подключении через 0.4 с.
- Не проверял: сборку полного ядра с этим оверлеем в CI (только модуль вручную), другие платы кроме WB8.

---
ИИ: текст подготовил ИИ-агент.
Модель: claude-fable-5-1 · Harness: Claude Code CLI 2.1.261 · Настройки: permission mode auto
Запустил и отвечает за содержимое: @evgeny-boger
